### PR TITLE
Improved PathHelper Item Segment detection

### DIFF
--- a/packages/sn-client-utils/src/PathHelper.ts
+++ b/packages/sn-client-utils/src/PathHelper.ts
@@ -26,11 +26,13 @@ export class PathHelper {
    */
   public static getSegments(path: string): string[] {
     return path
-      .split(/\/|[(][']/g)
+      .split(/\/|[(][']|[(]/g)
       .filter(segment => segment && segment.length)
       .map(segment => {
         if (segment.endsWith("')")) {
           segment = `('${segment}`
+        } else if (segment.endsWith(')')) {
+          segment = `(${segment}`
         }
         return segment
       })

--- a/packages/sn-client-utils/src/PathHelper.ts
+++ b/packages/sn-client-utils/src/PathHelper.ts
@@ -37,11 +37,11 @@ export class PathHelper {
   }
 
   /**
-   * Checks if a specific segment is an Item segment or not (like "('Content1')")
+   * Checks if a specific segment is an Item segment or not (like "('Content1')"" or "(654)")
    * @param segment The segment to be examined
    */
   public static isItemSegment(segment: string): boolean {
-    return segment.startsWith("('") && segment.endsWith("')")
+    return RegExp(/^\('+[\s\S]+'\)$/).test(segment) || RegExp(/^\(+\d+\)$/).test(segment)
   }
 
   /**

--- a/packages/sn-client-utils/test/PathHelperTests.ts
+++ b/packages/sn-client-utils/test/PathHelperTests.ts
@@ -5,12 +5,28 @@ import { PathHelper } from '../src'
  */
 export const pathHelperTests = describe('PathHelper', () => {
   describe('#isItemSegment()', () => {
-    it('Should return true for item segments', () => {
+    it('Should return true for item segments with string key "(\'Item1\')"', () => {
       expect(PathHelper.isItemSegment("('Item1')")).toBe(true)
+    })
+
+    it('Should return true for item segments with numeric key "(42)"', () => {
+      expect(PathHelper.isItemSegment('(42)')).toBe(true)
+    })
+
+    it('Should return false for string keys w/o quotes', () => {
+      expect(PathHelper.isItemSegment('(invalidValue)')).toBe(false)
+    })
+
+    it('Should return false for invalid string keys', () => {
+      expect(PathHelper.isItemSegment('(123invalidValue)')).toBe(false)
     })
 
     it('Should return false for non-item segments', () => {
       expect(PathHelper.isItemSegment('Item1')).toBe(false)
+    })
+
+    it('Should return false for inconsistent quotation', () => {
+      expect(PathHelper.isItemSegment("('123invalidValue)")).toBe(false)
     })
   })
 

--- a/packages/sn-client-utils/test/PathHelperTests.ts
+++ b/packages/sn-client-utils/test/PathHelperTests.ts
@@ -63,6 +63,11 @@ export const pathHelperTests = describe('PathHelper', () => {
       const isAnItem = PathHelper.isItemPath("/workspace/('project')/CustomAction")
       expect(isAnItem).toBe(true)
     })
+
+    it('should return true for reference paths with ids', () => {
+      const isAnItem = PathHelper.isItemPath('/workspaces/(22)/CustomAction')
+      expect(isAnItem).toBe(true)
+    })
   })
 
   describe('#getContentUrlbyId()', () => {


### PR DESCRIPTION
 - Improved the OData Item Segment detection in client-utils. Now it should work with string based keys e.g. **"('MyContent')"** and number based as well, e.g.: **(42)** (currently not used in sn, but common for other OData endpoints)
 - Replaced the .startsWith() and endsWith() statements with regexp
 - Additional unit tests