### PR TITLE
[client-core] Passing request inits to fetch

### DIFF
--- a/packages/sn-client-core/src/Models/RequestOptions.ts
+++ b/packages/sn-client-core/src/Models/RequestOptions.ts
@@ -18,6 +18,10 @@ export interface LoadOptions<TContentType> {
    * Optional content version parameter
    */
   version?: string
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -32,6 +36,10 @@ export interface LoadCollectionOptions<TContentType> {
    * an ODataOptions object
    */
   oDataOptions?: ODataParams<TContentType>
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -61,6 +69,10 @@ export interface PostOptions<TContentType> {
    * An optional OData Options object
    */
   oDataOptions?: ODataParams<TContentType>
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -80,6 +92,10 @@ export interface PatchOptions<TContentType> {
    * An optional OData Options object
    */
   oDataOptions?: ODataParams<TContentType>
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -99,6 +115,10 @@ export interface PutOptions<TContentType> {
    * An optional OData Options object
    */
   oDataOptions?: ODataParams<TContentType>
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -113,6 +133,10 @@ export interface DeleteOptions {
    * Permantent flag for a delete request
    */
   permanent?: boolean
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -131,6 +155,10 @@ export interface MoveOptions {
    * Optional content to call the action
    */
   rootContent?: Content
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -149,6 +177,10 @@ export interface CopyOptions {
    * Optional content to call the action
    */
   rootContent?: Content
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**
@@ -176,6 +208,10 @@ export interface ActionOptions<TBody, TContentType> {
    * An OData Options object
    */
   oDataOptions?: ODataParams<TContentType>
+  /**
+   * Additional fetch request init options
+   */
+  requestInit?: RequestInit
 }
 
 /**

--- a/packages/sn-client-core/src/Models/RequestOptions.ts
+++ b/packages/sn-client-core/src/Models/RequestOptions.ts
@@ -2,50 +2,56 @@ import { ObservableValue } from '@sensenet/client-utils'
 import { Content } from './Content'
 import { ODataParams } from './ODataParams'
 import { UploadProgressInfo } from './UploadProgressInfo'
+
 /**
- * Defines options for a Load request
+ * Request options with OData Model
  */
-export interface LoadOptions<TContentType> {
-  /**
-   * The content Id or path to load
-   */
-  idOrPath: string | number
+export interface WithOdataOptions<T> {
   /**
    * An OData Options object
    */
-  oDataOptions?: ODataParams<TContentType>
-  /**
-   * Optional content version parameter
-   */
-  version?: string
+  oDataOptions?: ODataParams<T>
+}
+
+/**
+ * Request options with Request Init parameter
+ */
+export interface WithRequestInit {
   /**
    * Additional fetch request init options
    */
   requestInit?: RequestInit
+}
+
+/**
+ * Defines options for a Load request
+ */
+export interface LoadOptions<TContentType> extends WithOdataOptions<TContentType>, WithRequestInit {
+  /**
+   * The content Id or path to load
+   */
+  idOrPath: string | number
+
+  /**
+   * Optional content version parameter
+   */
+  version?: string
 }
 
 /**
  * Defines options for a collection load request
  */
-export interface LoadCollectionOptions<TContentType> {
+export interface LoadCollectionOptions<TContentType> extends WithOdataOptions<TContentType>, WithRequestInit {
   /**
    * The collection path
    */
   path: string
-  /**
-   * an ODataOptions object
-   */
-  oDataOptions?: ODataParams<TContentType>
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Defines options for a Post request
  */
-export interface PostOptions<TContentType> {
+export interface PostOptions<TContentType> extends WithOdataOptions<TContentType>, WithRequestInit {
   /**
    * Path for a parent content
    */
@@ -64,21 +70,12 @@ export interface PostOptions<TContentType> {
    * An optional content template
    */
   contentTemplate?: string
-
-  /**
-   * An optional OData Options object
-   */
-  oDataOptions?: ODataParams<TContentType>
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Defines options for a patch request
  */
-export interface PatchOptions<TContentType> {
+export interface PatchOptions<TContentType> extends WithOdataOptions<TContentType>, WithRequestInit {
   /**
    * The id or path to the content that you want to patch
    */
@@ -87,21 +84,12 @@ export interface PatchOptions<TContentType> {
    * The content data to update
    */
   content: Partial<TContentType>
-
-  /**
-   * An optional OData Options object
-   */
-  oDataOptions?: ODataParams<TContentType>
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Defines options for a Put request
  */
-export interface PutOptions<TContentType> {
+export interface PutOptions<TContentType> extends WithOdataOptions<TContentType>, WithRequestInit {
   /**
    * The id or path to the content that you want to update
    */
@@ -110,21 +98,12 @@ export interface PutOptions<TContentType> {
    * The new content data
    */
   content: Partial<TContentType>
-
-  /**
-   * An optional OData Options object
-   */
-  oDataOptions?: ODataParams<TContentType>
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Options for a delete request
  */
-export interface DeleteOptions {
+export interface DeleteOptions extends WithRequestInit {
   /**
    * The id(s) or path(list) for a content(s) to delete
    */
@@ -133,16 +112,12 @@ export interface DeleteOptions {
    * Permantent flag for a delete request
    */
   permanent?: boolean
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Options for a content move request
  */
-export interface MoveOptions {
+export interface MoveOptions extends WithRequestInit {
   /**
    * The id(s) or path(list) for a content(s) to move
    */
@@ -155,16 +130,12 @@ export interface MoveOptions {
    * Optional content to call the action
    */
   rootContent?: Content
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Options for a content copy request
  */
-export interface CopyOptions {
+export interface CopyOptions extends WithRequestInit {
   /**
    * The id(s) or path(list) for a content(s) to copy
    */
@@ -177,16 +148,12 @@ export interface CopyOptions {
    * Optional content to call the action
    */
   rootContent?: Content
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
  * Options to call an odata action
  */
-export interface ActionOptions<TBody, TContentType> {
+export interface ActionOptions<TBody, TContentType> extends WithOdataOptions<TContentType>, WithRequestInit {
   /**
    * The name of the odata action
    */
@@ -203,15 +170,6 @@ export interface ActionOptions<TBody, TContentType> {
    * Additional body parameters
    */
   body?: TBody
-
-  /**
-   * An OData Options object
-   */
-  oDataOptions?: ODataParams<TContentType>
-  /**
-   * Additional fetch request init options
-   */
-  requestInit?: RequestInit
 }
 
 /**
@@ -232,7 +190,7 @@ export interface GetActionOptions {
 /**
  * Options for uploading content
  */
-export interface UploadOptions<T> {
+export interface UploadOptions<T> extends WithOdataOptions<T> {
   /**
    * The name of the content type, e.g.: File
    */
@@ -250,10 +208,6 @@ export interface UploadOptions<T> {
    */
   body?: any
 
-  /**
-   * Additional OData options
-   */
-  odataOptions?: ODataParams<T>
   /**
    * The path of the parent content
    */

--- a/packages/sn-client-core/src/Models/RequestOptions.ts
+++ b/packages/sn-client-core/src/Models/RequestOptions.ts
@@ -190,7 +190,7 @@ export interface GetActionOptions {
 /**
  * Options for uploading content
  */
-export interface UploadOptions<T> extends WithOdataOptions<T> {
+export interface UploadOptions<T> extends WithOdataOptions<T>, WithRequestInit {
   /**
    * The name of the content type, e.g.: File
    */

--- a/packages/sn-client-core/src/Repository/Repository.ts
+++ b/packages/sn-client-core/src/Repository/Repository.ts
@@ -115,6 +115,7 @@ export class Repository implements Disposable {
     const params = ODataUrlBuilder.buildUrlParamString(this.configuration, options.oDataOptions)
     const path = PathHelper.joinPaths(this.configuration.repositoryUrl, this.configuration.oDataToken, contentPath)
     const response = await this.fetch(`${path}?${params}`, {
+      ...options.requestInit,
       credentials: 'include',
       method: 'GET',
     })
@@ -134,6 +135,7 @@ export class Repository implements Disposable {
     const params = ODataUrlBuilder.buildUrlParamString(this.configuration, options.oDataOptions)
     const path = PathHelper.joinPaths(this.configuration.repositoryUrl, this.configuration.oDataToken, options.path)
     const response = await this.fetch(`${path}?${params}`, {
+      ...options.requestInit,
       credentials: 'include',
       method: 'GET',
     })
@@ -164,6 +166,7 @@ export class Repository implements Disposable {
     postBody.__ContentTemplate = options.contentTemplate
 
     const response = await this.fetch(`${path}?${params}`, {
+      ...options.requestInit,
       credentials: 'include',
       method: 'POST',
       body: JSON.stringify(postBody),
@@ -185,6 +188,7 @@ export class Repository implements Disposable {
     const path = PathHelper.joinPaths(this.configuration.repositoryUrl, this.configuration.oDataToken, contentPath)
     const params = ODataUrlBuilder.buildUrlParamString(this.configuration, options.oDataOptions)
     const response = await this.fetch(`${path}?${params}`, {
+      ...options.requestInit,
       credentials: 'include',
       method: 'PATCH',
       body: JSON.stringify(options.content),
@@ -206,6 +210,7 @@ export class Repository implements Disposable {
     const path = PathHelper.joinPaths(this.configuration.repositoryUrl, this.configuration.oDataToken, contentPath)
     const params = ODataUrlBuilder.buildUrlParamString(this.configuration, options.oDataOptions)
     const response = await this.fetch(`${path}?${params}`, {
+      ...options.requestInit,
       credentials: 'include',
       method: 'PUT',
       body: JSON.stringify(options.content),
@@ -232,6 +237,7 @@ export class Repository implements Disposable {
       idOrPath: ConstantContent.PORTAL_ROOT.Path,
       method: 'POST',
       name: 'DeleteBatch',
+      requestInit: options.requestInit,
       body: {
         paths: this.createArray(options.idOrPath),
         permanent: options.permanent,
@@ -248,6 +254,7 @@ export class Repository implements Disposable {
       idOrPath: ConstantContent.PORTAL_ROOT.Path,
       method: 'POST',
       name: 'MoveBatch',
+      requestInit: options.requestInit,
       body: {
         paths: this.createArray(options.idOrPath),
         targetPath: options.targetPath,
@@ -264,6 +271,7 @@ export class Repository implements Disposable {
       idOrPath: ConstantContent.PORTAL_ROOT.Path,
       method: 'POST',
       name: 'CopyBatch',
+      requestInit: options.requestInit,
       body: {
         paths: this.createArray(options.idOrPath),
         targetPath: options.targetPath,
@@ -387,6 +395,7 @@ export class Repository implements Disposable {
       options.name,
     )
     const requestOptions: RequestInit = {
+      ...options.requestInit,
       credentials: 'include',
       method: options.method,
     }

--- a/packages/sn-client-core/src/Repository/Upload.ts
+++ b/packages/sn-client-core/src/Repository/Upload.ts
@@ -113,6 +113,7 @@ export class Upload {
     const formData = this.getFormDataFromOptions(options)
     formData.append(options.file.name, options.file)
     const response = await this.repository.fetch(this.getUploadUrl(options), {
+      ...options.requestInit,
       credentials: 'include',
       method: 'POST',
       body: formData,
@@ -168,6 +169,7 @@ export class Upload {
     formData.append('UseChunk', 'true')
     formData.append('create', '1')
     const initRequest = await this.repository.fetch(uploadPath, {
+      ...options.requestInit,
       body: formData,
       credentials: 'include',
       method: 'POST',
@@ -197,6 +199,7 @@ export class Upload {
       chunkFormData.append(options.file.name, chunkData)
 
       const lastResponse = await this.repository.fetch(uploadPath, {
+        ...options.requestInit,
         body: chunkFormData,
         credentials: 'include',
         method: 'POST',


### PR DESCRIPTION
We should be able to pass additional request init options for each and every repository action that uses "fetch" (e.g. cancelling a request with an [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort))