### PR TITLE
[KFI]ci: deploy from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,35 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+cache:
+  yarn: true
 
-cache: yarn
+jobs:
+  include:
+    - stage: 'Tests'
+      name: 'Static linting'
+      script: yarn lint
 
-script:
-  - yarn
-  - yarn lint
-  - yarn build
-  - yarn test:coverage
+    - name: 'Unit Tests'
+      before_script: yarn build
+      script: yarn test:coverage
+      after_success: bash <(curl -s https://codecov.io/bash)
+
+    - stage: 'Deploy to netlify'
+      if: type = pull_request
+      name: 'DMS'
+      install: yarn && npm install netlify-cli -g
+      script: yarn build && yarn dms build:webpack
+      after_success: netlify deploy --site 12d988ec-f023-45e1-9f49-d05f8b309c42 --auth $NETLIFY_ACCESS_TOKEN --dir ./examples/sn-dms-demo/build --message $TRAVIS_PULL_REQUEST
+
+    - if: type = pull_request
+      name: 'Component docs'
+      install: yarn && npm install netlify-cli -g
+      script: yarn build && yarn storybook build-storybook
+      after_success: netlify deploy --site 2e86544e-b4b5-4f40-b1a0-a5d34367a03f --auth $NETLIFY_ACCESS_TOKEN --dir ./examples/sn-react-component-docs/storybook-static --message $TRAVIS_PULL_REQUEST
+
+    - if: type = pull_request
+      name: 'Sn app'
+      install: yarn && npm install netlify-cli -g
+      script: yarn build && yarn snapp build:webpack
+      after_success: netlify deploy --site eddadc9d-3e2d-42ab-a0c6-81b9d58fce84 --auth $NETLIFY_ACCESS_TOKEN --dir ./apps/sensenet/bundle/assets --message $TRAVIS_PULL_REQUEST

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "typescript": "3.4.2"
   },
   "scripts": {
-    "snapp": "yarn workspace @sensenet/sn-app start",
-    "storybook": "yarn workspace sn-react-component-docs start-storybook",
-    "dms": "yarn workspace sn-dms-demo start",
+    "snapp": "yarn workspace @sensenet/sn-app",
+    "storybook": "yarn workspace sn-react-component-docs",
+    "dms": "yarn workspace sn-dms-demo",
     "build": "tsc -b packages",
     "build:dms": "yarn && yarn build && yarn workspace sn-dms-demo run build:webpack",
     "build:sn-app": "yarn && yarn build && yarn workspace @sensenet/sn-app run build:webpack",


### PR DESCRIPTION
## Deploy to netlify with Travis CI 🎉

- removed start from scripts in package.json
it is now easier to run commands in storybook, dms demo, sn app.
eg.: `yarn dms build:webpack` or `yarn dms start`

- refactored Travis CI to use build stages