### PR TITLE
[admin-ui]: Content Type editing fixes

### DIFF
--- a/apps/sensenet/src/context/CurrentAncestors.tsx
+++ b/apps/sensenet/src/context/CurrentAncestors.tsx
@@ -3,7 +3,7 @@ import { debounce } from '@sensenet/client-utils'
 import { GenericContent } from '@sensenet/default-content-types'
 import React, { useContext, useEffect, useState } from 'react'
 import Semaphore from 'semaphore-async-await'
-import { useInjector, useRepository } from '../hooks'
+import { useInjector, useLogger, useRepository } from '../hooks'
 import { CurrentContentContext } from './CurrentContent'
 export const CurrentAncestorsContext = React.createContext<GenericContent[]>([])
 
@@ -16,6 +16,8 @@ export const CurrentAncestorsProvider: React.FunctionComponent = props => {
   const injector = useInjector()
   const eventHub = injector.getEventHub(repo.configuration.repositoryUrl)
   const [reloadToken, setReloadToken] = useState(1)
+
+  const logger = useLogger('CurrentAncestorsProvider')
 
   const requestReload = debounce(() => setReloadToken(Math.random()), 100)
 
@@ -78,7 +80,10 @@ export const CurrentAncestorsProvider: React.FunctionComponent = props => {
   }, [currentContent.Id, loadLock, reloadToken, repo])
 
   if (error) {
-    throw error
+    logger.warning({
+      message: `Error loading ancestors. ${error.toString()}`,
+      data: { details: { error }, relatedContent: currentContent, relatedRepository: repo.configuration.repositoryUrl },
+    })
   }
   return <CurrentAncestorsContext.Provider value={ancestors}>{props.children}</CurrentAncestorsContext.Provider>
 }

--- a/apps/sensenet/src/context/CurrentAncestors.tsx
+++ b/apps/sensenet/src/context/CurrentAncestors.tsx
@@ -81,7 +81,7 @@ export const CurrentAncestorsProvider: React.FunctionComponent = props => {
 
   if (error) {
     logger.warning({
-      message: `Error loading ancestors. ${error.toString()}`,
+      message: `Error loading ancestors. ${error.message}`,
       data: { details: { error }, relatedContent: currentContent, relatedRepository: repo.configuration.repositoryUrl },
     })
   }


### PR DESCRIPTION
The CurrentAncestors provider has broke the app if it could not load the ancestors list (e.g. editing a content type)
This PR changes this behavior, if the custom action fails:
 - [x] We won't throwi up the error
 - [x] Add a warning entry to the log with the related content and the error details
 - [x] The Ancestors list will contain only the Current Content