### PR TITLE
[admin-ui] Personal settings upgrade

### DIFF
--- a/apps/sensenet/src/components/edit/PersonalSettingsEditor.tsx
+++ b/apps/sensenet/src/components/edit/PersonalSettingsEditor.tsx
@@ -1,7 +1,9 @@
 import { deepMerge } from '@sensenet/client-utils'
 import React, { useContext, useEffect, useState } from 'react'
-import { CurrentContentContext, LocalizationContext } from '../../context'
-import { useInjector, usePersonalSettings, useRepository } from '../../hooks'
+import { FormControlLabel, Switch, Typography } from '@material-ui/core'
+import MonacoEditor from 'react-monaco-editor'
+import { CurrentContentContext, LocalizationContext, ResponsiveContext } from '../../context'
+import { useInjector, useRepository, useTheme } from '../../hooks'
 import { setupModel } from '../../services/MonacoModels/PersonalSettingsModel'
 import { defaultSettings, PersonalSettings } from '../../services/PersonalSettings'
 import { TextEditor } from './TextEditor'
@@ -9,9 +11,11 @@ import { TextEditor } from './TextEditor'
 const SettingsEditor: React.FunctionComponent = () => {
   const injector = useInjector()
   const service = injector.getInstance(PersonalSettings)
-  const settings = usePersonalSettings()
+  const settings = service.userValue.getValue()
   const localization = useContext(LocalizationContext)
   const repo = useRepository()
+  const theme = useTheme()
+  const platform = useContext(ResponsiveContext)
   const [editorContent] = useState({
     Type: 'PersonalSettings',
     Name: `PersonalSettings`,
@@ -21,16 +25,57 @@ const SettingsEditor: React.FunctionComponent = () => {
     setupModel(localization.values, repo)
   }, [localization.values, repo])
 
+  const [showDefaults, setShowDefaults] = useState(false)
+
   return (
     <CurrentContentContext.Provider
       value={{ Id: 0, Type: 'PersonalSettings', Path: '', Name: localization.values.personalSettings.title }}>
-      <TextEditor
-        content={editorContent as any}
-        loadContent={async () => JSON.stringify(settings, undefined, 3)}
-        saveContent={async (_c, v) => {
-          await service.setValue(deepMerge({ ...defaultSettings }, JSON.parse(v)))
-        }}
-      />
+      <div style={{ display: 'flex', width: '100%', height: '100%', overflow: 'hidden', flexDirection: 'row' }}>
+        <div
+          style={{
+            width: showDefaults ? '50%' : '0',
+            height: '100%',
+            transition: 'width 200ms cubic-bezier(0.215, 0.610, 0.355, 1.000)',
+            overflow: 'hidden',
+          }}>
+          <Typography variant="button" style={{ lineHeight: '60px', height: '60px', marginLeft: '2em' }}>
+            {localization.values.personalSettings.defaults}
+          </Typography>
+          <MonacoEditor
+            theme={theme.palette.type === 'dark' ? 'vs-dark' : 'vs-light'}
+            width="100%"
+            language={'json'}
+            value={JSON.stringify(defaultSettings, undefined, 2)}
+            options={{
+              readOnly: true,
+              automaticLayout: true,
+              minimap: {
+                enabled: platform === 'desktop' ? true : false,
+              },
+            }}
+          />
+        </div>
+        <div
+          style={{
+            width: showDefaults ? '50%' : '100%',
+            height: '100%',
+            transition: 'width 200ms cubic-bezier(0.215, 0.610, 0.355, 1.000)',
+          }}>
+          <TextEditor
+            content={editorContent as any}
+            loadContent={async () => JSON.stringify(settings, undefined, 3)}
+            additionalButtons={
+              <FormControlLabel
+                control={<Switch onClick={() => setShowDefaults(!showDefaults)} />}
+                label={localization.values.personalSettings.showDefaults}
+              />
+            }
+            saveContent={async (_c, v) => {
+              await service.setPersonalSettingsValue(deepMerge(JSON.parse(v)))
+            }}
+          />
+        </div>
+      </div>
     </CurrentContentContext.Provider>
   )
 }

--- a/apps/sensenet/src/components/edit/TextEditor.tsx
+++ b/apps/sensenet/src/components/edit/TextEditor.tsx
@@ -31,6 +31,7 @@ export interface TextEditorProps {
   content: SnFile
   loadContent?: (content: SnFile) => Promise<string>
   saveContent?: (content: SnFile, value: string) => Promise<void>
+  additionalButtons?: JSX.Element
 }
 
 export const TextEditor: React.FunctionComponent<TextEditorProps> = props => {
@@ -141,7 +142,12 @@ export const TextEditor: React.FunctionComponent<TextEditorProps> = props => {
       }}>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <ContentBreadcrumbs />
-        <div>
+        <div
+          style={{
+            display: 'flex',
+            marginRight: '1em',
+          }}>
+          {props.additionalButtons ? props.additionalButtons : null}
           <Button disabled={!hasChanges} onClick={() => setTextValue(savedTextValue)}>
             {localization.reset}
           </Button>

--- a/apps/sensenet/src/context/PersonalSettingsContext.tsx
+++ b/apps/sensenet/src/context/PersonalSettingsContext.tsx
@@ -5,11 +5,11 @@ export const PersonalSettingsContext = React.createContext(defaultSettings)
 export const PersonalSettingsContextProvider: React.StatelessComponent = props => {
   const di = useInjector()
   const settingsService = di.getInstance(PersonalSettings)
-  const [settings, setSettings] = useState(settingsService.currentValue.getValue())
+  const [settings, setSettings] = useState(settingsService.effectiveValue.getValue())
   useEffect(() => {
-    settingsService.currentValue.subscribe(s => {
+    settingsService.effectiveValue.subscribe(s => {
       setSettings(s)
     })
-  }, [settingsService.currentValue])
+  }, [settingsService.effectiveValue])
   return <PersonalSettingsContext.Provider value={settings}>{props.children}</PersonalSettingsContext.Provider>
 }

--- a/apps/sensenet/src/localization/default.ts
+++ b/apps/sensenet/src/localization/default.ts
@@ -143,6 +143,13 @@ const values = {
   personalSettings: {
     defaults: 'Defaults',
     showDefaults: 'Show defaults',
+    restoreDefaults: 'Restore defaults',
+    restoreDialogTitle: 'Really restore defaults?',
+    restoreDialogTText:
+      'Are you sure you want to restore the default settings? Your log will also be cleared and you will be signed out from all repositories.',
+    cancel: 'Cancel',
+    restore: 'Restore',
+    restoringDefaultsProgress: 'Restoring the default settings...',
     title: 'Personal settings',
     drawer: 'Options for the left drawer',
     drawerEnable: 'Enable or disable the drawer',

--- a/apps/sensenet/src/localization/default.ts
+++ b/apps/sensenet/src/localization/default.ts
@@ -141,6 +141,8 @@ const values = {
     logoutCancel: 'Cancel',
   },
   personalSettings: {
+    defaults: 'Defaults',
+    showDefaults: 'Show defaults',
     title: 'Personal settings',
     drawer: 'Options for the left drawer',
     drawerEnable: 'Enable or disable the drawer',

--- a/apps/sensenet/src/services/CommandProviders/QueryCommandProvider.ts
+++ b/apps/sensenet/src/services/CommandProviders/QueryCommandProvider.ts
@@ -21,7 +21,7 @@ export class QueryCommandProvider implements CommandProvider {
 
   public async getItems(options: SearchOptions): Promise<CommandPaletteItem[]> {
     const ctx = new ContentContextProvider(options.repository)
-    const extendedQuery = this.personalSettings.currentValue
+    const extendedQuery = this.personalSettings.effectiveValue
       .getValue()
       .default.commandPalette.wrapQuery.replace('{0}', options.term)
     const result = await options.repository.loadCollection<GenericContent>({

--- a/apps/sensenet/src/services/EventLogger.ts
+++ b/apps/sensenet/src/services/EventLogger.ts
@@ -7,7 +7,7 @@ import { PersonalSettings } from './PersonalSettings'
 export class EventLogger extends AbstractLogger {
   public async addEntry<T>(entry: LeveledLogEntry<T>): Promise<void> {
     if (
-      this.personalSettings.currentValue.getValue().logLevel.includes(LogLevel[entry.level] as keyof typeof LogLevel)
+      this.personalSettings.effectiveValue.getValue().logLevel.includes(LogLevel[entry.level] as keyof typeof LogLevel)
     ) {
       this.eventService.add(entry)
     }

--- a/apps/sensenet/src/services/EventService.ts
+++ b/apps/sensenet/src/services/EventService.ts
@@ -35,7 +35,7 @@ export class EventService {
 
   private storeChanges = debounce(() => {
     const values = [...this.values.getValue()]
-    const entries = values.slice(values.length - this.personalSettings.currentValue.getValue().eventLogSize)
+    const entries = values.slice(values.length - this.personalSettings.effectiveValue.getValue().eventLogSize)
     localStorage.setItem(EventService.storageKey, JSON.stringify(entries))
   }, EventService.storageDebounceInterval)
 

--- a/apps/sensenet/src/services/MonacoModels/PersonalSettingsModel.ts
+++ b/apps/sensenet/src/services/MonacoModels/PersonalSettingsModel.ts
@@ -272,7 +272,6 @@ export const setupModel = (language = defaultLanguage, repo: Repository) => {
             },
           },
           type: 'object',
-          required: ['default', 'repositories', 'lastRepository'],
           properties: {
             default: { $ref: '#/definitions/settings' },
             mobile: { $ref: '#/definitions/settings' },

--- a/apps/sensenet/src/services/PersonalSettings.ts
+++ b/apps/sensenet/src/services/PersonalSettings.ts
@@ -243,7 +243,8 @@ export class PersonalSettings {
 
   public async getLocalUserSettingsValue(): Promise<Partial<PersonalSettingsType>> {
     try {
-      return JSON.parse(localStorage.getItem(`${settingsKey}`) as string)
+      const stored = localStorage.getItem(`${settingsKey}`) as string
+      return JSON.parse(stored || '{}')
     } catch {
       /** */
     }

--- a/apps/sensenet/src/services/PersonalSettings.ts
+++ b/apps/sensenet/src/services/PersonalSettings.ts
@@ -237,7 +237,8 @@ export class PersonalSettings {
 
   private async init() {
     const currentUserSettings = await this.getLocalUserSettingsValue()
-    this.currentValue.setValue(deepMerge(defaultSettings, currentUserSettings))
+    this.userValue.setValue(currentUserSettings)
+    this.effectiveValue.setValue(deepMerge(defaultSettings, currentUserSettings))
   }
 
   public async getLocalUserSettingsValue(): Promise<Partial<PersonalSettingsType>> {
@@ -249,10 +250,13 @@ export class PersonalSettings {
     return {}
   }
 
-  public currentValue = new ObservableValue(defaultSettings)
+  public effectiveValue = new ObservableValue(defaultSettings)
 
-  public async setValue(settings: PersonalSettingsType) {
-    this.currentValue.setValue({ ...settings })
+  public userValue = new ObservableValue<Partial<PersonalSettingsType>>({})
+
+  public async setPersonalSettingsValue(settings: Partial<PersonalSettingsType>) {
+    this.userValue.setValue(settings)
+    this.effectiveValue.setValue(deepMerge(defaultSettings, settings))
     localStorage.setItem(`${settingsKey}`, JSON.stringify(settings))
   }
 }


### PR DESCRIPTION
Implemented *restore defaults* functionality for personal settings and made some minor improvements.

The Personal Settings started to overgrow so I've changed the evaluation logic and on the UI.
 - [x] Changed the personal settings evaluation. Settings will be merged with the defaults only on evaluation, not on (or before) save. The personal settings editor will show only the *overridden* values.
 - [x] Changed the Monaco model, removed all required *root* fields
 - [x] Added "Show defaults" option to the personal settings editor
 - [x] Add "reset to defaults" functionality