### PR TITLE
fix(admin-ui):Search routing and select / expand Actions

### DIFF
--- a/apps/sensenet/src/components/content-list/index.tsx
+++ b/apps/sensenet/src/components/content-list/index.tsx
@@ -101,8 +101,8 @@ export const CollectionComponent: React.FunctionComponent<CollectionComponentPro
         loadSettings.loadChildrenSettings.orderby && loadSettings.loadChildrenSettings.orderby.length === 1
           ? [[currentOrder as any, order as any]]
           : [['DisplayName', 'asc']],
-      select: props.fieldsToDisplay,
-      expand: (props.fieldsToDisplay || []).filter(f => f === 'Actions' || isReferenceField(f, repo)),
+      select: ['Actions', ...(props.fieldsToDisplay || [])],
+      expand: ['Actions', ...(props.fieldsToDisplay || []).filter(f => isReferenceField(f, repo))],
     })
     setCurrentOrder(currentOrder)
     setCurrentDirection(currentDirection)

--- a/apps/sensenet/src/components/content/index.tsx
+++ b/apps/sensenet/src/components/content/index.tsx
@@ -12,7 +12,7 @@ import { SimpleList } from './Simple'
 export const BrowseType = tuple('commander', 'explorer', 'simple')
 
 export interface BrowseData {
-  type: typeof BrowseType[number]
+  type?: typeof BrowseType[number]
   root?: string
   currentContent?: number | string
   secondaryContent?: number | string // right parent
@@ -35,7 +35,10 @@ export const Content: React.FunctionComponent<RouteComponentProps<{ browseData: 
   useEffect(() => {
     try {
       const data = decodeBrowseData(props.match.params.browseData)
-      setBrowseData(data)
+      setBrowseData({
+        ...browseData,
+        ...data,
+      })
     } catch (error) {
       logger.warning({ message: 'Wrong link :(' })
     }

--- a/apps/sensenet/src/components/dashboard/query-widget.tsx
+++ b/apps/sensenet/src/components/dashboard/query-widget.tsx
@@ -14,6 +14,7 @@ import {
   CurrentContentContext,
   LoadSettingsContext,
 } from '../../context'
+import { encodeQueryData } from '../search'
 
 const QueryWidget: React.FunctionComponent<QueryWidgetModel<GenericContent> & RouteComponentProps> = props => {
   const [items, setItems] = useState<GenericContent[]>([])
@@ -92,7 +93,9 @@ const QueryWidget: React.FunctionComponent<QueryWidgetModel<GenericContent> & Ro
               style={{ padding: '0', margin: '0 0 0 1em' }}
               onClick={() =>
                 props.history.push(
-                  `/${btoa(repo.configuration.repositoryUrl)}/search/${encodeURIComponent(props.settings.query)}`,
+                  `/${btoa(repo.configuration.repositoryUrl)}/search/${encodeQueryData({
+                    term: props.settings.query,
+                  })}`,
                 )
               }>
               <OpenInNewTwoTone />

--- a/apps/sensenet/src/components/search/index.tsx
+++ b/apps/sensenet/src/components/search/index.tsx
@@ -86,9 +86,8 @@ const Search: React.FunctionComponent<RouteComponentProps<{ queryData?: string }
         path: ConstantContent.PORTAL_ROOT.Path,
         oDataOptions: {
           ...loadSettingsContext.loadChildrenSettings,
-          select: queryData.fieldsToDisplay,
-          expand: (queryData.fieldsToDisplay || []).filter(f => f === 'Actions' || isReferenceField(f, repo)),
-
+          select: ['Actions', ...(queryData.fieldsToDisplay || [])],
+          expand: ['Actions', ...(queryData.fieldsToDisplay || []).filter(f => isReferenceField(f, repo))],
           query: personalSettings.commandPalette.wrapQuery.replace('{0}', queryData.term),
           top: loadCount,
         },

--- a/apps/sensenet/src/components/search/saved-queries.tsx
+++ b/apps/sensenet/src/components/search/saved-queries.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../context'
 import { useInjector, useLocalization, useRepository } from '../../hooks'
 import { CollectionComponent } from '../content-list'
+import { encodeQueryData } from '.'
 
 const Search: React.FunctionComponent<RouteComponentProps> = props => {
   const repo = useRepository()
@@ -104,9 +105,9 @@ const Search: React.FunctionComponent<RouteComponentProps> = props => {
                   }}
                   onActivateItem={p => {
                     props.history.push(
-                      `/${btoa(repo.configuration.repositoryUrl)}/search/${encodeURIComponent(
-                        (p as Query).Query || '',
-                      )}`,
+                      `/${btoa(repo.configuration.repositoryUrl)}/search/${encodeQueryData({
+                        term: (p as Query).Query || '',
+                      })}`,
                     )
                   }}
                   onTabRequest={() => {

--- a/apps/sensenet/src/components/search/saved-queries.tsx
+++ b/apps/sensenet/src/components/search/saved-queries.tsx
@@ -81,7 +81,7 @@ const Search: React.FunctionComponent<RouteComponentProps> = props => {
         <Tooltip title={localization.newSearch}>
           <Link
             style={{ textDecoration: 'none', position: 'fixed', bottom: '2em', right: '2em' }}
-            to={`/${repoToken}/search`}>
+            to={`/${repoToken}/search/${encodeQueryData({ term: '' })}`}>
             <Fab color="primary" title={localization.newSearch}>
               <SearchIcon />
             </Fab>

--- a/apps/sensenet/src/services/CommandProviders/QueryCommandProvider.ts
+++ b/apps/sensenet/src/services/CommandProviders/QueryCommandProvider.ts
@@ -6,6 +6,7 @@ import { ContentContextProvider } from '../ContentContextProvider'
 import { LocalizationService } from '../LocalizationService'
 import { PersonalSettings } from '../PersonalSettings'
 import { CommandPaletteItem } from '../../hooks'
+import { encodeQueryData } from '../../components/search'
 
 @Injectable({ lifetime: 'singleton' })
 export class QueryCommandProvider implements CommandProvider {
@@ -48,7 +49,9 @@ export class QueryCommandProvider implements CommandProvider {
       {
         primaryText: this.localization.currentValues.getValue().search.openInSearchTitle,
         secondaryText: this.localization.currentValues.getValue().search.openInSearchDescription,
-        url: `/${btoa(options.repository.configuration.repositoryUrl)}/search/${encodeURIComponent(options.term)}`,
+        url: `/${btoa(options.repository.configuration.repositoryUrl)}/search/${encodeQueryData({
+          term: options.term,
+        })}`,
         content: { Type: 'Search' } as any,
         hits: [],
       },

--- a/apps/sensenet/src/services/ContentContextProvider.ts
+++ b/apps/sensenet/src/services/ContentContextProvider.ts
@@ -8,6 +8,7 @@ import {
   File as SnFile,
 } from '@sensenet/default-content-types'
 import { isContentFromType } from '../utils/isContentFromType'
+import { encodeBrowseData } from '../components/content'
 
 export type RouteType =
   | 'Browse'
@@ -108,6 +109,9 @@ export class ContentContextProvider {
       return `/${repoSegment}/wopi/${content.Id}/${routeType === 'WopiEdit' ? 'edit' : 'read'}`
     }
 
+    if (routeType === 'Browse') {
+      return `/${repoSegment}/${routeType}/${encodeBrowseData({ currentContent: content.Id })}`
+    }
     return `/${repoSegment}/${routeType}/${content.Id}`
   }
   public getPrimaryActionUrl<T extends GenericContent>(content: T) {


### PR DESCRIPTION
As the **search / query** routing has been changed from ``/:repo/search/:term`` to ``/:repo/search/:encodedQueryData`` we had to update those components that create query / search URLs
 - [x] Query widget
 - [x] Query command provider
 - [x] Saved queries
----
 - [x] Fixed Routing context Browse URL generation (e.g. in breadcrumbs)
 - [x] Modified the Search and Content views to always ``$select`` and ``$expand`` **Actions** (for context menus, WOPI check)