### PR TITLE
Fix execute custom action from Command Palette

### DIFF
--- a/apps/sensenet/src/services/CommandProviders/CustomActionCommandProvider.ts
+++ b/apps/sensenet/src/services/CommandProviders/CustomActionCommandProvider.ts
@@ -40,7 +40,11 @@ export class CustomActionCommandProvider implements CommandProvider {
     const actions = (result.d.Actions as ActionModel[]) || []
 
     return actions
-      .filter(a => a.Name.toLowerCase().includes(filteredTerm) || a.DisplayName.toLowerCase().includes(filteredTerm))
+      .filter(
+        a =>
+          (a.Name.toLowerCase().includes(filteredTerm) && a.IsODataAction) ||
+          (a.DisplayName.toLowerCase().includes(filteredTerm) && a.IsODataAction),
+      )
       .map(a => {
         const actionMetadata =
           result.d.__metadata &&

--- a/packages/sn-client-core/src/Models/MetadataAction.ts
+++ b/packages/sn-client-core/src/Models/MetadataAction.ts
@@ -11,4 +11,5 @@ export interface MetadataAction {
     type: string
     required: boolean
   }>
+  isODataAction: boolean
 }

--- a/packages/sn-default-content-types/src/ActionModel.ts
+++ b/packages/sn-default-content-types/src/ActionModel.ts
@@ -35,4 +35,8 @@ export interface ActionModel {
    * Shows if the action is forbidden
    */
   Forbidden: boolean
+  /**
+   * Shows if the action is an ODataAction
+   */
+  IsODataAction: boolean
 }


### PR DESCRIPTION
- Non-odata actions are now hidden from the result list