### PR TITLE
Update CI to use Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '10'
+  - '12'
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
The `CONTRIBUTING.md` file states that you should "make sure your node, npm, and yarn are on the latest versions". However, the CI uses an older Node version.

This PR updates the CI to use the latest Node version (12), in order to align the CI with the statement in the documentation.