### PR TITLE
chore(controls): material ui warning fix

### DIFF
--- a/packages/sn-controls-react/src/fieldcontrols/TagsInput.tsx
+++ b/packages/sn-controls-react/src/fieldcontrols/TagsInput.tsx
@@ -162,6 +162,16 @@ export class TagsInput extends Component<ReactClientFieldSetting<ReferenceFieldS
     this.props.fieldOnChange && this.props.fieldOnChange(this.props.settings.Name, newValue.map(content => content.Id))
   }
 
+  /**
+   * Get proper value for the Select componet
+   */
+  public getValue() {
+    if (this.props.settings.AllowMultiple) {
+      return this.state.fieldValue.length ? this.state.fieldValue.map(c => c.Id) : []
+    }
+    return this.state.fieldValue.length ? this.state.fieldValue.map(c => c.Id) : ''
+  }
+
   public render() {
     switch (this.props.actionName) {
       case 'edit':
@@ -174,8 +184,9 @@ export class TagsInput extends Component<ReactClientFieldSetting<ReferenceFieldS
             required={this.props.settings.Compulsory}>
             <InputLabel htmlFor={this.props.settings.Name}>{this.props.settings.DisplayName}</InputLabel>
             <Select
-              value={this.state.fieldValue}
+              value={this.getValue()}
               onChange={this.handleChange}
+              multiple={this.props.settings.AllowMultiple}
               input={<Input id={this.props.settings.Name} fullWidth={true} />}
               renderValue={() => (
                 <div style={styles.chips as any}>

--- a/packages/sn-controls-react/src/fieldcontrols/TagsInput.tsx
+++ b/packages/sn-controls-react/src/fieldcontrols/TagsInput.tsx
@@ -169,7 +169,7 @@ export class TagsInput extends Component<ReactClientFieldSetting<ReferenceFieldS
     if (this.props.settings.AllowMultiple) {
       return this.state.fieldValue.length ? this.state.fieldValue.map(c => c.Id) : []
     }
-    return this.state.fieldValue.length ? this.state.fieldValue.map(c => c.Id) : ''
+    return this.state.fieldValue.length ? this.state.fieldValue.map(c => c.Id)[0] : ''
   }
 
   public render() {

--- a/packages/sn-controls-react/test/TagsInput.test.tsx
+++ b/packages/sn-controls-react/test/TagsInput.test.tsx
@@ -88,7 +88,12 @@ describe('Tags input field control', () => {
     it('should show the value of the field when content is passed', async () => {
       const consoleSpy = jest.spyOn(console, 'error')
       const wrapper = mount(
-        <TagsInput actionName="edit" settings={defaultSettings} content={userContent} repository={repository} />,
+        <TagsInput
+          actionName="edit"
+          settings={{ ...defaultSettings, AllowMultiple: true }}
+          content={userContent}
+          repository={repository}
+        />,
       )
       expect(consoleSpy).not.toBeCalled()
       await sleepAsync(0)
@@ -101,7 +106,7 @@ describe('Tags input field control', () => {
       const wrapper = mount(
         <TagsInput
           actionName="edit"
-          settings={defaultSettings}
+          settings={{ ...defaultSettings, AllowMultiple: true }}
           content={userContent}
           fieldOnChange={fieldOnChange}
           repository={repository}


### PR DESCRIPTION
Select componet value should be array when the multiple
property is true and a string when it is false.