### PR TITLE
Set ev.target.files empty after every change

### DIFF
--- a/apps/sensenet/src/components/dialogs/upload/upload-dialog.tsx
+++ b/apps/sensenet/src/components/dialogs/upload/upload-dialog.tsx
@@ -211,7 +211,10 @@ export function UploadDialog(props: UploadDialogProps) {
         </Grid>
       </DialogContent>
       <input
-        onChange={ev => ev.target.files && addFiles([...ev.target.files])}
+        onChange={ev => {
+          ev.target.files && addFiles([...ev.target.files])
+          ev.target.value = ''
+        }}
         style={{ display: 'none' }}
         ref={inputFile}
         type="file"

--- a/apps/sensenet/src/components/dialogs/upload/upload-dialog.tsx
+++ b/apps/sensenet/src/components/dialogs/upload/upload-dialog.tsx
@@ -108,6 +108,11 @@ export function UploadDialog(props: UploadDialogProps) {
       return
     }
     setFiles(files.filter(f => f !== file))
+
+    // it can access to select the same file again after removal. Check: https://github.com/sensenet/sn-client/issues/491
+    if (inputFile.current) {
+      inputFile.current.value = ''
+    }
   }
 
   const addFiles = (fileList: FileWithFullPath[]) => {
@@ -213,7 +218,6 @@ export function UploadDialog(props: UploadDialogProps) {
       <input
         onChange={ev => {
           ev.target.files && addFiles([...ev.target.files])
-          ev.target.value = ''
         }}
         style={{ display: 'none' }}
         ref={inputFile}


### PR DESCRIPTION
If you select a file for upload it will be stored in ev.target.files, but if you cancel the upload and select the same file again onChange won't be called [- cause your input will be the same as in ev.target.files-] . 
My solution was to set event.target.value to an empty string which set the event.target.files empty as well.