### PR TITLE
ci: use webpack plugin for bundle stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,3 @@ jobs:
       install: yarn && npm install netlify-cli -g
       script: yarn build && yarn snapp build
       after_success: wait-on $SN_BOT_URL -l -t 60000 && netlify deploy --site 94fb346c-b540-40f7-aaaf-21eee2a9c891 --auth $NETLIFY_ACCESS_TOKEN --dir ./apps/sensenet/build --message $TRAVIS_PULL_REQUEST
-
-    - name: 'Sn app stats'
-      script: yarn build && yarn snapp build:stats && yarn snapp send-relative-ci

--- a/apps/sensenet/package.json
+++ b/apps/sensenet/package.json
@@ -17,7 +17,6 @@
     "fix:prettier": "prettier \"{,!(dist|temp|bundle)/**/}*.{ts,tsx}\" --write",
     "build": "webpack --config webpack.prod.js",
     "build:stats": "webpack --config webpack.prod.js --profile --json > stats.json",
-    "send-relative-ci": "relative-ci-agent",
     "start": "webpack-dev-server --open --progress --config webpack.dev.js"
   },
   "private": true,

--- a/apps/sensenet/relativeci.config.js
+++ b/apps/sensenet/relativeci.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  includeCommitMessage: true,
-  webpack: {
-    stats: 'stats.json',
-  },
-}

--- a/apps/sensenet/webpack.prod.js
+++ b/apps/sensenet/webpack.prod.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const { RelativeCiAgentWebpackPlugin } = require('@relative-ci/agent')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
@@ -56,6 +57,7 @@ module.exports = merge(common, {
       { from: path.resolve(`${__dirname}/_redirects`), to: path.resolve(`${__dirname}/build`) },
       { from: path.resolve(`${__dirname}/web.config`), to: path.resolve(`${__dirname}/build`) },
     ]),
+    new RelativeCiAgentWebpackPlugin(),
   ],
   module: {
     rules: [


### PR DESCRIPTION
It is advised to use the webpack plugin in relative-ci. This way we don't have to:

1. Run a new travis job
2. Less configuration and code in snapp