### PR TITLE
Missing redux actions

### DIFF
--- a/examples/sn-dms-demo/src/components/Dialogs/AddNewDialog.tsx
+++ b/examples/sn-dms-demo/src/components/Dialogs/AddNewDialog.tsx
@@ -30,7 +30,7 @@ const mapStateToProps = (state: rootStateType) => {
 const mapDispatchToProps = {
   closeDialog: DMSActions.closeDialog,
   createContent: Actions.createContent,
-  getSchema: Actions.getSchema,
+  getSchema: Actions.getSchemaByTypeName,
 }
 
 const LoadableNewView = Loadable({

--- a/examples/sn-dms-demo/src/components/Dialogs/EditPropertiesDialog.tsx
+++ b/examples/sn-dms-demo/src/components/Dialogs/EditPropertiesDialog.tsx
@@ -36,7 +36,7 @@ const mapDispatchToProps = {
   openDialog: DMSActions.openDialog,
   editContent: Actions.updateContent,
   loadEditedContent,
-  getSchema: Actions.getSchemaByType,
+  getSchema: Actions.getSchemaByTypeName,
 }
 
 interface EditPropertiesDialogState {

--- a/examples/sn-dms-demo/src/components/Dialogs/EditPropertiesDialog.tsx
+++ b/examples/sn-dms-demo/src/components/Dialogs/EditPropertiesDialog.tsx
@@ -36,7 +36,7 @@ const mapDispatchToProps = {
   openDialog: DMSActions.openDialog,
   editContent: Actions.updateContent,
   loadEditedContent,
-  getSchema: Actions.getSchema,
+  getSchema: Actions.getSchemaByType,
 }
 
 interface EditPropertiesDialogState {

--- a/packages/sn-redux/src/Actions.ts
+++ b/packages/sn-redux/src/Actions.ts
@@ -508,8 +508,8 @@ export const changeFieldValue = (name: string, value: any) => ({
  * Action creator for loading schema of a given type
  * @param {string} typeName Name of the Content Type.
  */
-export const getSchema = (typeName: string) => ({
-  type: 'GET_SCHEMA',
+export const getSchemaByTypeName = (typeName: string) => ({
+  type: 'GET_SCHEMA_BY_TYPENAME',
   payload: (repository: Repository) => repository.schemas.getSchemaByName(typeName),
 })
 /**
@@ -571,3 +571,16 @@ export const getMetadata = (idOrPath: string | number) => {
     payload: (repository: Repository) => repository.fetch(`${path}/$metadata`),
   }
 }
+
+/**
+ * Action creator for loading repository schema
+ */
+export const getSchema = () => ({
+  type: 'GET_SCHEMA',
+  payload: (repository: Repository) =>
+    repository.executeAction({
+      idOrPath: '/Root',
+      name: 'GetSchema',
+      method: 'GET',
+    }),
+})

--- a/packages/sn-redux/test/actions.test.ts
+++ b/packages/sn-redux/test/actions.test.ts
@@ -24,10 +24,7 @@ const jwtMockResponse = {
   },
 } as Response
 
-const repository = new Repository(
-  { repositoryUrl: 'https://dmsservice.demo.sensenet.com/' },
-  async () => jwtMockResponse,
-)
+const repository = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => jwtMockResponse)
 
 export const _jwtService = new JwtService(repository)
 
@@ -115,18 +112,51 @@ const metadataResponse = {
   'content-type': 'application/xml; charset=utf-8',
 }
 
+const schemaResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return [
+      {
+        ContentTypeName: 'ContentType',
+        DisplayName: 'Content Type',
+        Description: 'A content type is a reusable set of fields you want to apply to certain content.',
+        Icon: 'ContentType',
+        AllowIndexing: true,
+        AllowIncrementalNaming: false,
+        AllowedChildTypes: [],
+        HandlerName: 'SenseNet.ContentRepository.Schema.ContentType',
+        FieldSettings: [
+          {
+            Type: 'IntegerFieldSetting',
+            Name: 'Id',
+            FieldClassName: 'SenseNet.ContentRepository.Fields.IntegerField',
+            DisplayName: 'Id',
+            Description: 'A unique ID for the Content.',
+            ReadOnly: true,
+            Compulsory: false,
+            OutputMethod: 0,
+            Visible: false,
+            VisibleBrowse: 1,
+            VisibleEdit: 1,
+            VisibleNew: 1,
+            DefaultOrder: 0,
+          },
+        ],
+      },
+    ]
+  },
+} as Response
+
 describe('Actions', () => {
   const path = '/workspaces/project'
   let repo: Repository
   beforeEach(() => {
-    repo = new Repository({ repositoryUrl: 'https://dmsservice.demo.sensenet.com/' }, async () => contentMockResponse)
+    repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => contentMockResponse)
   })
   describe('FetchContent', () => {
     beforeEach(() => {
-      repo = new Repository(
-        { repositoryUrl: 'https://dmsservice.demo.sensenet.com/' },
-        async () => collectionMockResponse,
-      )
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => collectionMockResponse)
     })
     describe('Action types are types', () => {
       expect(Actions.requestContent(path, { scenario: '' }).type).toBe('FETCH_CONTENT')
@@ -211,7 +241,7 @@ describe('Actions', () => {
   })
   describe('LoadContentActions', () => {
     beforeEach(() => {
-      repo = new Repository({ repositoryUrl: 'https://dmsservice.demo.sensenet.com/' }, async () => actionsMockResponse)
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => actionsMockResponse)
     })
     describe('Action types are types', () => {
       expect(Actions.loadContentActions(path).type).toBe('LOAD_CONTENT_ACTIONS')
@@ -767,15 +797,15 @@ describe('Actions', () => {
       expect(Actions.changeFieldValue('Name', 'aaa')).toEqual(expectedAction)
     })
   })
-  describe('getSchema', () => {
+  describe('getSchemaByTypeName', () => {
     beforeEach(() => {
-      repo = new Repository({ repositoryUrl: 'https://dmsservice.demo.sensenet.com/' }, async () => contentMockResponse)
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => contentMockResponse)
     })
     describe('Action types are types', () => {
-      expect(Actions.getSchema('Task').type).toBe('GET_SCHEMA')
+      expect(Actions.getSchemaByTypeName('Task').type).toBe('GET_SCHEMA_BY_TYPENAME')
     })
     it('should return task schema', () => {
-      const data = Actions.getSchema('Task').payload(repo)
+      const data = Actions.getSchemaByTypeName('Task').payload(repo)
       expect(data).toEqual(repo.schemas.getSchemaByName('Task'))
     })
   })
@@ -792,10 +822,7 @@ describe('Actions', () => {
   })
   describe('getChildrenCount', () => {
     beforeEach(() => {
-      repo = new Repository(
-        { repositoryUrl: 'https://dmsservice.demo.sensenet.com/' },
-        async () => countResponse as any,
-      )
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => countResponse as any)
     })
     describe('Action types are types', () => {
       expect(Actions.getChildrenCount(path).type).toBe('GET_CHILDREN_COUNT')
@@ -818,10 +845,7 @@ describe('Actions', () => {
   })
   describe('getProperty', () => {
     beforeEach(() => {
-      repo = new Repository(
-        { repositoryUrl: 'https://dmsservice.demo.sensenet.com/' },
-        async () => propertyResponse as any,
-      )
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => propertyResponse as any)
     })
     describe('Action types are types', () => {
       expect(Actions.getProperty(path, 'DisplayName').type).toBe('GET_PROPERTY')
@@ -845,7 +869,7 @@ describe('Actions', () => {
   describe('getPropertyValue', () => {
     beforeEach(() => {
       repo = new Repository(
-        { repositoryUrl: 'https://dmsservice.demo.sensenet.com/' },
+        { repositoryUrl: 'https://dev.demo.sensenet.com/' },
         async () => propertyValueResponse as any,
       )
     })
@@ -870,10 +894,7 @@ describe('Actions', () => {
   })
   describe('getMetadata', () => {
     beforeEach(() => {
-      repo = new Repository(
-        { repositoryUrl: 'https://dmsservice.demo.sensenet.com/' },
-        async () => metadataResponse as any,
-      )
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => metadataResponse as any)
     })
     describe('Action types are types', () => {
       expect(Actions.getMetadata(path).type).toBe('GET_METADATA')
@@ -890,6 +911,30 @@ describe('Actions', () => {
         })
         it('should return propertyResponse', () => {
           expect(data).toEqual(metadataResponse)
+        })
+      })
+    })
+  })
+  describe('getSchema', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => schemaResponse as any)
+    })
+    describe('Action types are types', () => {
+      expect(Actions.getSchema().type).toBe('GET_SCHEMA')
+    })
+    describe('serviceChecks()', () => {
+      describe('Given repository.getSchema() resolves', () => {
+        let data
+        let mockSchemaResponseData: ReturnType<typeof schemaResponse['json']>
+        beforeEach(async () => {
+          data = await Actions.getSchema().payload(repo)
+          mockSchemaResponseData = await schemaResponse.json()
+        })
+        it('should return a GET_SCHEMA action', () => {
+          expect(Actions.getSchema()).toHaveProperty('type', 'GET_SCHEMA')
+        })
+        it('should return mockdata', () => {
+          expect(data).toEqual(mockSchemaResponseData)
         })
       })
     })


### PR DESCRIPTION
- new action for getting the full schema is created with the name `getSchema` (the old action with the same name is renamed to getSchemaByTypeName) 
- additionally dmsservice and devservice url-s are changed to dev.demo in files that are affected by this pr