### PR TITLE
ci: build snapp on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
       - name: build examples
         run: yarn build:examples
 
+      - name: build snapp
+        run: yarn snapp build
+        env:
+          RELATIVE_CI_KEY: ${{ secrets.RELATIVE_CI_KEY }}
+
       - name: test
         run: yarn test --coverage
 


### PR DESCRIPTION
Relative CI check was missing. Added snapp build to CI check on push also build_and_test job should pass to be able to merge changes to develop and master.