### PR TITLE
fix: console errors in tests

### DIFF
--- a/packages/sn-client-core/test/repository.test.ts
+++ b/packages/sn-client-core/test/repository.test.ts
@@ -98,13 +98,12 @@ describe('Repository', () => {
 
     describe('count', () => {
       it('should construct the url to contain /$count', async () => {
-        let url: string
         const countRepository = new Repository(undefined, input => {
-          url = input.toString()
+          const url = input.toString()
+          expect(url).toMatch(/http:\/\/localhost\/odata.svc\/Root\/Content\/\$count/g)
           return Promise.resolve({ ok: true, json: () => 42 }) as any
         })
         await countRepository.count({ path: '/Root/Content' })
-        expect(url).toMatch(/http:\/\/localhost\/odata.svc\/Root\/Content\/\$count/g)
       })
 
       it('should throw on unsuccessfull request', async () => {

--- a/packages/sn-controls-react/src/fieldcontrols/TagsInput.tsx
+++ b/packages/sn-controls-react/src/fieldcontrols/TagsInput.tsx
@@ -177,7 +177,7 @@ export class TagsInput extends Component<ReactClientFieldSetting<ReferenceFieldS
     if (this.props.settings.AllowMultiple) {
       return this.state.fieldValue.length ? this.state.fieldValue.map(c => c.Id) : []
     }
-    return this.state.fieldValue.length ? [this.state.fieldValue[0].Id] : []
+    return this.state.fieldValue.length ? [this.state.fieldValue[0].Id] : ''
   }
 
   public render() {
@@ -204,7 +204,7 @@ export class TagsInput extends Component<ReactClientFieldSetting<ReferenceFieldS
                         <Chip
                           avatar={
                             <Avatar
-                              alt={content.DisplayName}
+                              alt={`The avatar of ${content.DisplayName}`}
                               src={
                                 content.Avatar && content.Avatar.Url
                                   ? `${this.props.repository!.configuration.repositoryUrl}${content.Avatar.Url}`

--- a/packages/sn-controls-react/test/TagsInput.test.tsx
+++ b/packages/sn-controls-react/test/TagsInput.test.tsx
@@ -1,11 +1,10 @@
-import React from 'react'
-import { mount, shallow } from 'enzyme'
-import FormControlLabel from '@material-ui/core/FormControlLabel'
-import FormLabel from '@material-ui/core/FormLabel'
-import Select from '@material-ui/core/Select'
-import { sleepAsync } from '@sensenet/client-utils'
 import Chip from '@material-ui/core/Chip'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import Select from '@material-ui/core/Select'
 import SvgIcon from '@material-ui/core/SvgIcon'
+import { sleepAsync } from '@sensenet/client-utils'
+import { mount, shallow } from 'enzyme'
+import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { TagsInput } from '../src/fieldcontrols/TagsInput'
 
@@ -55,7 +54,6 @@ const repository: any = {
 describe('Tags input field control', () => {
   describe('in browse view', () => {
     it('should show the value of the field when content is passed', async () => {
-      const consoleSpy = jest.spyOn(console, 'error')
       const wrapper = mount(
         <TagsInput
           actionName="browse"
@@ -64,14 +62,13 @@ describe('Tags input field control', () => {
           repository={repository}
         />,
       )
-      expect(consoleSpy).not.toBeCalled()
       await sleepAsync(0)
       const updatedWrapper = wrapper.update()
       expect(updatedWrapper.find(FormControlLabel).children()).toHaveLength(1)
     })
 
     it('should not show anything when field value is not provided', () => {
-      const wrapper = shallow(<TagsInput actionName="browse" settings={defaultSettings} />)
+      const wrapper = shallow(<TagsInput actionName="browse" repository={repository} settings={defaultSettings} />)
       expect(wrapper.get(0)).toBeFalsy()
     })
   })

--- a/packages/sn-controls-react/test/__mocks__/schema.ts
+++ b/packages/sn-controls-react/test/__mocks__/schema.ts
@@ -9,6 +9,7 @@ export const schema = [
     AllowIndexing: true,
     AllowIncrementalNaming: false,
     AllowedChildTypes: [],
+    HandlerName: 'a',
     FieldSettings: [
       {
         Name: 'DisplayName',

--- a/packages/sn-list-controls-react/src/ContentList/CellTemplates/ActionsCell.tsx
+++ b/packages/sn-list-controls-react/src/ContentList/CellTemplates/ActionsCell.tsx
@@ -57,7 +57,7 @@ export class ActionsCell<T extends GenericContent> extends React.Component<Actio
   public render() {
     return (
       <TableCell
-        component="div"
+        component={this.props.virtual ? 'div' : 'td'}
         style={
           this.props.virtual
             ? {

--- a/packages/sn-list-controls-react/src/ContentList/CellTemplates/DateCell.tsx
+++ b/packages/sn-list-controls-react/src/ContentList/CellTemplates/DateCell.tsx
@@ -22,7 +22,7 @@ export const DateCell: React.StatelessComponent<DateCellProps> = props => {
             }
           : {}
       }
-      component="div">
+      component={props.virtual ? 'div' : 'td'}>
       <Moment fromNow={true}>{props.date}</Moment>
     </TableCell>
   )

--- a/packages/sn-list-controls-react/src/ContentList/CellTemplates/ReferenceCell.tsx
+++ b/packages/sn-list-controls-react/src/ContentList/CellTemplates/ReferenceCell.tsx
@@ -25,7 +25,7 @@ export class ReferenceCell<T extends GenericContent> extends React.Component<Ref
               }
             : {}
         }
-        component="div">
+        component={virtual ? 'div' : 'td'}>
         <span>{content[fieldName]}</span>
       </TableCell>
     )

--- a/packages/sn-list-controls-react/src/ContentList/ContentList.tsx
+++ b/packages/sn-list-controls-react/src/ContentList/ContentList.tsx
@@ -138,34 +138,29 @@ export const ContentList: React.FC<ContentListProps<GenericContent>> = props => 
                 />
               </TableCell>
             ) : null}
-            {props.fieldsToDisplay
-              ? props.fieldsToDisplay.map(field => {
-                  const fieldSetting = getSchemaForField(field)
-                  const isNumeric =
-                    fieldSetting &&
-                    (fieldSetting.Type === 'IntegerFieldSetting' || fieldSetting.Type === 'NumberFieldSetting')
-                  const description = (fieldSetting && fieldSetting.Description) || field
-                  const displayName = (fieldSetting && fieldSetting.DisplayName) || field
-                  return (
-                    <TableCell
-                      key={field as string}
-                      align={isNumeric ? 'right' : 'inherit'}
-                      className={field as string}>
-                      <Tooltip title={description}>
-                        <TableSortLabel
-                          active={props.orderBy === field}
-                          direction={props.orderDirection}
-                          onClick={() =>
-                            props.onRequestOrderChange &&
-                            props.onRequestOrderChange(field, props.orderDirection === 'asc' ? 'desc' : 'asc')
-                          }>
-                          {displayName}
-                        </TableSortLabel>
-                      </Tooltip>
-                    </TableCell>
-                  )
-                })
-              : null}
+            {props.fieldsToDisplay.map(field => {
+              const fieldSetting = getSchemaForField(field)
+              const isNumeric =
+                fieldSetting &&
+                (fieldSetting.Type === 'IntegerFieldSetting' || fieldSetting.Type === 'NumberFieldSetting')
+              const description = (fieldSetting && fieldSetting.Description) || field
+              const displayName = (fieldSetting && fieldSetting.DisplayName) || field
+              return (
+                <TableCell key={field as string} align={isNumeric ? 'right' : 'inherit'} className={field as string}>
+                  <Tooltip title={description}>
+                    <TableSortLabel
+                      active={props.orderBy === field}
+                      direction={props.orderDirection}
+                      onClick={() =>
+                        props.onRequestOrderChange &&
+                        props.onRequestOrderChange(field, props.orderDirection === 'asc' ? 'desc' : 'asc')
+                      }>
+                      {displayName}
+                    </TableSortLabel>
+                  </Tooltip>
+                </TableCell>
+              )
+            })}
           </TableRow>
         </TableHead>
       )}
@@ -202,21 +197,19 @@ export const ContentList: React.FC<ContentListProps<GenericContent>> = props => 
                   )}
                 </TableCell>
               ) : null}
-              {props.fieldsToDisplay
-                ? props.fieldsToDisplay.map(field => {
-                    const fieldSetting = getSchemaForField(field)
-                    const cellProps: CellProps = {
-                      ...(props as ContentListProps),
-                      field,
-                      content: item,
-                      fieldSetting,
-                      isSelected,
-                    }
+              {props.fieldsToDisplay.map(field => {
+                const fieldSetting = getSchemaForField(field)
+                const cellProps: CellProps = {
+                  ...(props as ContentListProps),
+                  field,
+                  content: item,
+                  fieldSetting,
+                  isSelected,
+                }
 
-                    const FieldComponent = props.fieldComponent || defaultFieldComponents
-                    return <FieldComponent key={cellProps.field} {...cellProps} />
-                  })
-                : null}
+                const FieldComponent = props.fieldComponent || defaultFieldComponents
+                return <FieldComponent key={cellProps.field} {...cellProps} />
+              })}
             </TableRow>
           )
         })}

--- a/packages/sn-list-controls-react/test/__snapshots__/content-list.test.tsx.snap
+++ b/packages/sn-list-controls-react/test/__snapshots__/content-list.test.tsx.snap
@@ -3177,54 +3177,6 @@ exports[`ContentList component Selection and active item changes Event bindings 
 </WithStyles(ForwardRef(Table))>
 `;
 
-exports[`ContentList component Selection and active item changes Event bindings should render without crashing without fieldsToDisplay 1`] = `
-<WithStyles(ForwardRef(Table))>
-  <WithStyles(ForwardRef(TableHead))>
-    <WithStyles(ForwardRef(TableRow))>
-      <WithStyles(ForwardRef(TableCell))
-        key="selectAll"
-        padding="checkbox"
-        style={
-          Object {
-            "paddingRight": 0,
-            "width": "30px",
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Checkbox))
-          checked={false}
-          className="select-all"
-          indeterminate={false}
-          onChange={[Function]}
-        />
-      </WithStyles(ForwardRef(TableCell))>
-    </WithStyles(ForwardRef(TableRow))>
-  </WithStyles(ForwardRef(TableHead))>
-  <WithStyles(ForwardRef(TableBody))>
-    <WithStyles(ForwardRef(TableRow))
-      className="  type-folder"
-      hover={true}
-      key="1"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onTouchEnd={[Function]}
-      selected={false}
-    >
-      <WithStyles(ForwardRef(TableCell))
-        key="select"
-        padding="checkbox"
-      >
-        <WithStyles(ForwardRef(Checkbox))
-          checked={false}
-          onChange={[Function]}
-        />
-      </WithStyles(ForwardRef(TableCell))>
-    </WithStyles(ForwardRef(TableRow))>
-  </WithStyles(ForwardRef(TableBody))>
-</WithStyles(ForwardRef(Table))>
-`;
-
 exports[`ContentList component Selection and active item changes Event bindings should render without crashing without icons 1`] = `
 <WithStyles(ForwardRef(Table))>
   <WithStyles(ForwardRef(TableHead))>

--- a/packages/sn-list-controls-react/test/content-list.test.tsx
+++ b/packages/sn-list-controls-react/test/content-list.test.tsx
@@ -682,21 +682,6 @@ describe('ContentList component', () => {
         expect(component).toMatchSnapshot()
         component.unmount()
       })
-      it('should render without crashing without fieldsToDisplay', () => {
-        const component = shallow(
-          <ContentList
-            items={[{ Id: 1, Name: '1', Path: '1', DisplayName: 'A', Type: 'Folder' }]}
-            schema={genericSchema}
-            selected={[]}
-            orderBy="DisplayName"
-            orderDirection="asc"
-            icons={{}}
-            displayRowCheckbox={true}
-          />,
-        )
-        expect(component).toMatchSnapshot()
-        component.unmount()
-      })
     })
   })
 })

--- a/packages/sn-list-controls-react/test/virtualized-table.test.tsx
+++ b/packages/sn-list-controls-react/test/virtualized-table.test.tsx
@@ -119,7 +119,7 @@ describe('Virtualized Table component', () => {
                 height: 400,
                 width: 800,
                 headerHeight: 42,
-                rowGetter: ({ index }) => items[index],
+                rowGetter: ({ index }: any) => items[index],
               } as any
             }
           />
@@ -165,7 +165,7 @@ describe('Virtualized Table component', () => {
                 height: 400,
                 width: 800,
                 headerHeight: 42,
-                rowGetter: ({ index }) => items[index],
+                rowGetter: ({ index }: any) => items[index],
               } as any
             }
           />
@@ -208,7 +208,7 @@ describe('Virtualized Table component', () => {
                 height: 400,
                 width: 800,
                 headerHeight: 42,
-                rowGetter: ({ index }) => items[index],
+                rowGetter: ({ index }: any) => items[index],
               } as any
             }
           />
@@ -250,7 +250,7 @@ describe('Virtualized Table component', () => {
                 height: 400,
                 width: 800,
                 headerHeight: 42,
-                rowGetter: ({ index }) => items[index],
+                rowGetter: ({ index }: any) => items[index],
               } as any
             }
           />
@@ -292,7 +292,7 @@ describe('Virtualized Table component', () => {
                 height: 400,
                 width: 800,
                 headerHeight: 42,
-                rowGetter: ({ index }) => items[index],
+                rowGetter: ({ index }: any) => items[index],
               } as any
             }
           />
@@ -324,12 +324,12 @@ describe('Virtualized Table component', () => {
                 headerHeight: 42,
                 height: 400,
                 width: 800,
-                onRowClick: rowMouseEventHandlerParams => {
+                onRowClick: (rowMouseEventHandlerParams: any) => {
                   expect(rowMouseEventHandlerParams.rowData.Id).toBe(1)
                   component.unmount()
                   done()
                 },
-                rowGetter: ({ index }) => items[index],
+                rowGetter: ({ index }: any) => items[index],
               } as any
             }
           />
@@ -390,7 +390,7 @@ describe('Virtualized Table component', () => {
                   height: 400,
                   width: 800,
                   headerHeight: 42,
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -426,7 +426,7 @@ describe('Virtualized Table component', () => {
                   width: 800,
                   rowHeight: 57,
                   headerHeight: 42,
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -463,7 +463,7 @@ describe('Virtualized Table component', () => {
                   headerHeight: 42,
                   height: 400,
                   width: 800,
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -506,7 +506,7 @@ describe('Virtualized Table component', () => {
                   headerHeight: 42,
                   height: 400,
                   width: 800,
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -536,9 +536,7 @@ describe('Virtualized Table component', () => {
               cellRenderer={props => {
                 if (props.tableCellProps.dataKey === 'Name') {
                   return (
-                    <td>
-                      <div className="custom-field">{props.tableCellProps.rowData[props.tableCellProps.dataKey]}</div>
-                    </td>
+                    <span className="custom-field">{props.tableCellProps.rowData[props.tableCellProps.dataKey]}</span>
                   )
                 }
                 return null
@@ -550,7 +548,7 @@ describe('Virtualized Table component', () => {
                   headerHeight: 42,
                   width: 800,
                   height: 400,
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -586,12 +584,12 @@ describe('Virtualized Table component', () => {
                   headerHeight: 42,
                   height: 400,
                   width: 800,
-                  onRowClick: rowMouseEventHandlerParams => {
+                  onRowClick: (rowMouseEventHandlerParams: any) => {
                     expect(rowMouseEventHandlerParams.rowData.Id).toBe(1)
                     component.unmount()
                     done()
                   },
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -621,12 +619,12 @@ describe('Virtualized Table component', () => {
                   headerHeight: 42,
                   height: 400,
                   width: 800,
-                  onRowDoubleClick: param => {
+                  onRowDoubleClick: (param: any) => {
                     expect(param.rowData.Id).toBe(1)
                     component.unmount()
                     done()
                   },
-                  rowGetter: ({ index }) => items[index],
+                  rowGetter: ({ index }: any) => items[index],
                 } as any
               }
             />
@@ -708,7 +706,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               fieldsToDisplay={['DisplayName']}
               selected={[]}
               orderBy="DisplayName"
@@ -734,7 +732,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               fieldsToDisplay={['DisplayName']}
               orderBy="DisplayName"
               orderDirection="asc"
@@ -759,7 +757,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               selected={undefined}
               fieldsToDisplay={['DisplayName']}
               orderBy="DisplayName"
@@ -785,7 +783,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               selected={undefined}
               fieldsToDisplay={['DisplayName']}
               orderBy="DisplayName"
@@ -811,7 +809,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={content}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               selected={content}
               fieldsToDisplay={['DisplayName']}
               orderBy="DisplayName"
@@ -838,7 +836,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               fieldsToDisplay={['DisplayName']}
               selected={[]}
               orderDirection="asc"
@@ -863,7 +861,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               fieldsToDisplay={['DisplayName']}
               selected={[]}
               orderBy="DisplayName"
@@ -888,7 +886,7 @@ describe('Virtualized Table component', () => {
           <Paper style={{ height: 400, width: '100%' }}>
             <VirtualizedTable
               items={items}
-              schema={genericSchema.DisplayName}
+              schema={genericSchema.DisplayName as any}
               fieldsToDisplay={['DisplayName']}
               selected={[]}
               orderBy="DisplayName"

--- a/packages/sn-redux/test/actions.test.ts
+++ b/packages/sn-redux/test/actions.test.ts
@@ -950,7 +950,7 @@ describe('Actions', () => {
     })
     describe('serviceChecks()', () => {
       describe('Given repository.getSchema() resolves', () => {
-        let data
+        let data: any
         let mockSchemaResponseData: ReturnType<typeof schemaResponse['json']>
         beforeEach(async () => {
           data = await Actions.getSchema().payload(repo)
@@ -1018,7 +1018,7 @@ describe('Actions', () => {
 
     describe('serviceChecks()', () => {
       describe('Given repository.removeSharing() resolves', () => {
-        let data: ODataSharingResponse
+        let data: any
         const expectedResult = { Token: 'devdog@sensenet.com', Id: 11 }
         beforeEach(async () => {
           data = await Actions.removeSharing({ Id: 42 } as GenericContent, 11).payload(repo)


### PR DESCRIPTION
There were some annoying console errors when tests run. Also fixed typescript errors in tests.

There are still 2 more console warning about components not compatible with React 16.9.
`react-quill` and `react-autosuggest`
react-autosuggest warning https://github.com/moroshko/react-autosuggest/pull/681#issuecomment-601065649 is going to go away once released.
react-quill is waiting for https://github.com/zenoamaro/react-quill/pull/549. It might not get merged anytime soon.