### PR TITLE
DocViewer fixes

### DIFF
--- a/apps/sensenet/src/components/DocViewer.tsx
+++ b/apps/sensenet/src/components/DocViewer.tsx
@@ -1,4 +1,14 @@
-import { DocumentViewer } from '@sensenet/document-viewer-react'
+import {
+  DocumentTitlePager,
+  DocumentViewer,
+  LayoutAppBar,
+  RotateActivePagesWidget,
+  RotateDocumentWidget,
+  ToggleCommentsWidget,
+  ToggleThumbnailsWidget,
+  ZoomInOutWidget,
+  ZoomModeWidget,
+} from '@sensenet/document-viewer-react'
 import React, { useCallback, useEffect } from 'react'
 import { RouteComponentProps, withRouter } from 'react-router'
 import { Close } from '@material-ui/icons'
@@ -16,8 +26,6 @@ const useStyles = makeStyles(() => {
     closeButton: {
       placeSelf: 'flex-end',
       position: 'relative',
-      top: '1em',
-      right: '4.5em',
     },
   })
 })
@@ -57,10 +65,25 @@ const DocViewer: React.FunctionComponent<RouteComponentProps<{ documentId: strin
     <div className={clsx(globalClasses.full, classes.docViewerWrapper)}>
       <CurrentContentProvider idOrPath={documentId} onContentLoaded={c => selectionService.activeContent.setValue(c)}>
         <DocumentViewer documentIdOrPath={documentId}>
-          <Button className={classes.closeButton} onClick={closeViewer}>
-            <Close style={{ marginRight: theme.spacing(1) }} />
-            {localization.customActions.resultsDialog.closeButton}
-          </Button>
+          <LayoutAppBar>
+            <div style={{ flexShrink: 0 }}>
+              <ToggleThumbnailsWidget />
+              <ZoomInOutWidget />
+              <ZoomModeWidget />
+              <RotateActivePagesWidget />
+              <RotateDocumentWidget />
+            </div>
+            <DocumentTitlePager />
+            <div style={{ display: 'flex', flexShrink: 0 }}>
+              <ToggleCommentsWidget />
+            </div>
+            <div style={{ display: 'flex', flexShrink: 0 }}>
+              <Button className={classes.closeButton} onClick={closeViewer}>
+                <Close style={{ marginRight: theme.spacing(1) }} />
+                {localization.customActions.resultsDialog.closeButton}
+              </Button>
+            </div>
+          </LayoutAppBar>
         </DocumentViewer>
       </CurrentContentProvider>
     </div>

--- a/examples/sn-react-component-docs/stories/viewer/DocumentViewer.stories.tsx
+++ b/examples/sn-react-component-docs/stories/viewer/DocumentViewer.stories.tsx
@@ -29,8 +29,8 @@ storiesOf('DocumentViewer', module)
         comment={{
           createdBy: object('Created by', createdBy),
           page: 1,
-          x: 10,
-          y: 10,
+          x: '10',
+          y: '10',
           id: text('id', 'randomId'),
           text: text(
             'commentBody',
@@ -52,8 +52,8 @@ storiesOf('DocumentViewer', module)
         comment={{
           createdBy: object('Created by', createdBy),
           page: 1,
-          x: 10,
-          y: 10,
+          x: '10',
+          y: '10',
           id: text('id', 'randomId'),
           text: text('commentBody', `Lorem ipsum dolor is single short text`),
         }}

--- a/packages/sn-document-viewer-react/src/components/Page.tsx
+++ b/packages/sn-document-viewer-react/src/components/Page.tsx
@@ -142,12 +142,10 @@ export const Page: React.FC<PageProps> = props => {
         return
       }
       const newCommentMarker = {
-        x:
-          event.nativeEvent.offsetX / (relativeImageSize.height / ((page.image && page.image.Height) || 1)) -
-          MARKER_SIZE,
-        y:
-          event.nativeEvent.offsetY / (relativeImageSize.height / ((page.image && page.image.Height) || 1)) -
-          MARKER_SIZE,
+        x: `${event.nativeEvent.offsetX / (relativeImageSize.height / ((page.image && page.image.Height) || 1)) -
+          MARKER_SIZE}`,
+        y: `${event.nativeEvent.offsetY / (relativeImageSize.height / ((page.image && page.image.Height) || 1)) -
+          MARKER_SIZE}`,
         id: 'draft',
       }
       commentState.setDraft(newCommentMarker)

--- a/packages/sn-document-viewer-react/src/components/document-widgets/RotateActivePages.tsx
+++ b/packages/sn-document-viewer-react/src/components/document-widgets/RotateActivePages.tsx
@@ -28,14 +28,14 @@ export const RotateActivePagesWidget: React.FC = () => {
     <div style={{ display: 'inline-block' }}>
       <IconButton
         color="inherit"
-        title={localization.rotateDocumentLeft}
+        title={localization.rotatePageLeft}
         onClick={() => rotateDocumentLeft()}
         id="RotateActiveLeft">
         <RotateLeft />
       </IconButton>
       <IconButton
         color="inherit"
-        title={localization.rotateDocumentRight}
+        title={localization.rotatePageRight}
         onClick={() => rotateDocumentRight()}
         id="RotateActiveRight">
         <RotateRight />

--- a/packages/sn-document-viewer-react/src/components/document-widgets/RotateDocument.tsx
+++ b/packages/sn-document-viewer-react/src/components/document-widgets/RotateDocument.tsx
@@ -28,12 +28,8 @@ export const RotateDocumentWidget: React.FC = () => {
 
   return (
     <div style={{ display: 'inline-block' }}>
-      <IconButton
-        title={localization.rotateDocumentLeft}
-        onClick={rotateDocumentLeft}
-        style={{ border: '2px solid', borderRadius: '5px' }}
-        id="RotateLeft">
-        <RotateLeft />
+      <IconButton title={localization.rotateDocumentLeft} onClick={rotateDocumentLeft} id="RotateLeft">
+        <RotateLeft style={{ border: '2px solid', borderRadius: '5px' }} />
       </IconButton>
       <IconButton title={localization.rotateDocumentRight} onClick={rotateDocumentRight} id="RotateRight">
         <RotateRight style={{ border: '2px solid', borderRadius: '5px' }} />

--- a/packages/sn-document-viewer-react/src/components/document-widgets/ToggleBase.tsx
+++ b/packages/sn-document-viewer-react/src/components/document-widgets/ToggleBase.tsx
@@ -30,7 +30,7 @@ export const ToggleBase: React.FunctionComponent<ToggleBaseProps> = props => (
       color={props.isVisible ? 'primary' : 'inherit'}
       title={props.title}
       onClick={() => props.setValue(!props.isVisible)}
-      style={{ opacity: props.isVisible ? 1 : 0.5 }}>
+      style={{ opacity: props.isVisible ? 0.5 : 1 }}>
       {props.children}
     </IconButton>
   </div>

--- a/packages/sn-document-viewer-react/src/components/document-widgets/ToggleComments.tsx
+++ b/packages/sn-document-viewer-react/src/components/document-widgets/ToggleComments.tsx
@@ -11,10 +11,10 @@ export const ToggleCommentsWidget: React.FC = () => {
   const viewerState = useViewerState()
   return (
     <ToggleBase
-      isVisible={false}
+      isVisible={viewerState.showComments}
       title={localization.toggleComments}
       setValue={v => viewerState.updateState({ showComments: v })}>
-      <Comment fill="#ffffff" />
+      <Comment color="action" fill={viewerState.showComments ? '#ffffff' : '#ffffff'} />
     </ToggleBase>
   )
 }

--- a/packages/sn-document-viewer-react/src/components/document-widgets/ToggleComments.tsx
+++ b/packages/sn-document-viewer-react/src/components/document-widgets/ToggleComments.tsx
@@ -11,10 +11,10 @@ export const ToggleCommentsWidget: React.FC = () => {
   const viewerState = useViewerState()
   return (
     <ToggleBase
-      isVisible={viewerState.showComments}
+      isVisible={false}
       title={localization.toggleComments}
       setValue={v => viewerState.updateState({ showComments: v })}>
-      <Comment />
+      <Comment fill="#ffffff" />
     </ToggleBase>
   )
 }

--- a/packages/sn-document-viewer-react/src/components/document-widgets/ToggleThumbnails.tsx
+++ b/packages/sn-document-viewer-react/src/components/document-widgets/ToggleThumbnails.tsx
@@ -18,7 +18,7 @@ export const ToggleThumbnailsWidget: React.FC = () => {
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
         style={{ width: '1em', height: '1em' }}
-        fill={viewerState.showThumbnails ? styles.colors.icon.active : styles.colors.icon.inactive}
+        fill={viewerState.showThumbnails ? styles.colors.icon.inactive : styles.colors.icon.active}
         viewBox="0 0 1000 1000"
         enableBackground="new 0 0 1000 1000">
         <g>

--- a/packages/sn-document-viewer-react/src/components/page-widgets/style.ts
+++ b/packages/sn-document-viewer-react/src/components/page-widgets/style.ts
@@ -13,8 +13,8 @@ export const MARKER_SIZE = 10
 
 export const CommentMarker = styled('div')<{ marker: DraftCommentMarker; zoomRatio: number; isSelected: boolean }>`
   position: absolute;
-  top: ${props => props.marker.y * props.zoomRatio}px;
-  left: ${props => props.marker.x * props.zoomRatio}px;
+  top: ${props => parseFloat(props.marker.y) * props.zoomRatio}px;
+  left: ${props => parseFloat(props.marker.x) * props.zoomRatio}px;
   width: ${MARKER_SIZE}px;
   height: ${MARKER_SIZE}px;
   border-radius: ${MARKER_SIZE}px;

--- a/packages/sn-document-viewer-react/src/components/styles.ts
+++ b/packages/sn-document-viewer-react/src/components/styles.ts
@@ -9,10 +9,10 @@ export const styles = {
     sidebar: '#eaeaeb',
     appBar: '#2a2a2c',
     icon: {
-      inactive: '#707070',
-      active: '#3c91f2',
+      inactive: '#ffffff',
+      active: '#ffffff',
     },
-    commentButton: '#ff9800',
+    commentButton: '#ffffff',
   },
 }
 

--- a/packages/sn-document-viewer-react/src/models/Comment.ts
+++ b/packages/sn-document-viewer-react/src/models/Comment.ts
@@ -16,8 +16,8 @@ export interface CommentData {
   id: string
   createdBy: CreatedByUser
   page: number
-  x: number
-  y: number
+  x: string
+  y: string
   text: string
 }
 

--- a/packages/sn-document-viewer-react/test/Page.test.tsx
+++ b/packages/sn-document-viewer-react/test/Page.test.tsx
@@ -79,6 +79,6 @@ describe('Page component', () => {
       .find('div')
       .at(1)
       .simulate('click', { nativeEvent: { offsetX: 3, offsetY: 3 } })
-    expect(setDraft).toBeCalledWith({ id: 'draft', x: -6, y: -6 })
+    expect(setDraft).toBeCalledWith({ id: 'draft', x: '-6', y: '-6' })
   })
 })

--- a/packages/sn-document-viewer-react/test/__snapshots__/RotateActivePage.test.tsx.snap
+++ b/packages/sn-document-viewer-react/test/__snapshots__/RotateActivePage.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
       color="inherit"
       id="RotateActiveLeft"
       onClick={[Function]}
-      title="Rotate document left"
+      title="Rotate page left"
     >
       <ForwardRef(IconButton)
         classes={
@@ -32,7 +32,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
         color="inherit"
         id="RotateActiveLeft"
         onClick={[Function]}
-        title="Rotate document left"
+        title="Rotate page left"
       >
         <WithStyles(ForwardRef(ButtonBase))
           centerRipple={true}
@@ -41,7 +41,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
           focusRipple={true}
           id="RotateActiveLeft"
           onClick={[Function]}
-          title="Rotate document left"
+          title="Rotate page left"
         >
           <ForwardRef(ButtonBase)
             centerRipple={true}
@@ -57,7 +57,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
             focusRipple={true}
             id="RotateActiveLeft"
             onClick={[Function]}
-            title="Rotate document left"
+            title="Rotate page left"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
@@ -76,7 +76,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
               onTouchMove={[Function]}
               onTouchStart={[Function]}
               tabIndex={0}
-              title="Rotate document left"
+              title="Rotate page left"
               type="button"
             >
               <span
@@ -153,7 +153,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
       color="inherit"
       id="RotateActiveRight"
       onClick={[Function]}
-      title="Rotate document right"
+      title="Rotate page right"
     >
       <ForwardRef(IconButton)
         classes={
@@ -172,7 +172,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
         color="inherit"
         id="RotateActiveRight"
         onClick={[Function]}
-        title="Rotate document right"
+        title="Rotate page right"
       >
         <WithStyles(ForwardRef(ButtonBase))
           centerRipple={true}
@@ -181,7 +181,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
           focusRipple={true}
           id="RotateActiveRight"
           onClick={[Function]}
-          title="Rotate document right"
+          title="Rotate page right"
         >
           <ForwardRef(ButtonBase)
             centerRipple={true}
@@ -197,7 +197,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
             focusRipple={true}
             id="RotateActiveRight"
             onClick={[Function]}
-            title="Rotate document right"
+            title="Rotate page right"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
@@ -216,7 +216,7 @@ exports[`RotateActivePage component Should render without crashing 1`] = `
               onTouchMove={[Function]}
               onTouchStart={[Function]}
               tabIndex={0}
-              title="Rotate document right"
+              title="Rotate page right"
               type="button"
             >
               <span

--- a/packages/sn-document-viewer-react/test/__snapshots__/ToggleWidgets.test.tsx.snap
+++ b/packages/sn-document-viewer-react/test/__snapshots__/ToggleWidgets.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Component ToggleBase should render without crashing 1`] = `
     onClick={[Function]}
     style={
       Object {
-        "opacity": 1,
+        "opacity": 0.5,
       }
     }
     title="Test"
@@ -53,7 +53,7 @@ exports[`Component ToggleThumbnails should render without crashing 1`] = `
 >
   <svg
     enableBackground="new 0 0 1000 1000"
-    fill="#707070"
+    fill="#ffffff"
     style={
       Object {
         "height": "1em",


### PR DESCRIPTION
- [x] toolbar is added, so now thumbnails and comments could be shown
- [x] additionally added to the toolbar: zooming, rotating and fitting functions
- [x] fix: adding comments returned error always, because the x and y coordinates were floating numbers and the request body was not a valid json. These two params' type is changed to string.

TODOs for the future (issues should be created):
(Each of the below feature has its placeholder, a button without the actual function implemented.)

- [ ] comments revamp and missing stuff
- [ ] download
- [ ] print
- [ ] save
- [ ] share
- [ ] watermark
- [ ] managing shapes