### PR TITLE
Fix wopi actions' visiblity

### DIFF
--- a/apps/sensenet/src/components/context-menu/content-context-menu.tsx
+++ b/apps/sensenet/src/components/context-menu/content-context-menu.tsx
@@ -42,13 +42,14 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
         logger.verbose({ message: 'There are no actions in content', data: contentFromCallback })
         return
       }
+      const contentActions = contentFromCallback.Actions.filter(action => !action.Forbidden)
 
       if (isWriteAvailable(contentFromCallback)) {
         // If write is available it means that we have two actions. We want to show only the open edit for the user.
-        const actionsWithoutWopiRead = contentFromCallback.Actions.filter(action => action.Name !== 'WopiOpenView')
+        const actionsWithoutWopiRead = contentActions.filter(action => action.Name !== 'WopiOpenView')
         setActions(actionsWithoutWopiRead)
       } else {
-        setActions(contentFromCallback.Actions)
+        setActions(contentActions)
       }
     },
     [isWriteAvailable, logger],
@@ -80,7 +81,7 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
           open={props.isOpened}
           PaperProps={{ style: { paddingBottom: '2em' } }}>
           <List>
-            {actions?.map(action => {
+            {actions.map(action => {
               return (
                 <ListItem
                   key={action.Name}
@@ -98,7 +99,7 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
         </Drawer>
       ) : (
         <Menu open={props.isOpened} {...props.menuProps}>
-          {actions?.map(action => {
+          {actions.map(action => {
             return (
               <MenuItem
                 key={action.Name}

--- a/apps/sensenet/src/components/context-menu/content-context-menu.tsx
+++ b/apps/sensenet/src/components/context-menu/content-context-menu.tsx
@@ -81,7 +81,7 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
           open={props.isOpened}
           PaperProps={{ style: { paddingBottom: '2em' } }}>
           <List>
-            {actions.map(action => {
+            {actions?.map(action => {
               return (
                 <ListItem
                   key={action.Name}
@@ -99,7 +99,7 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
         </Drawer>
       ) : (
         <Menu open={props.isOpened} {...props.menuProps}>
-          {actions.map(action => {
+          {actions?.map(action => {
             return (
               <MenuItem
                 key={action.Name}

--- a/packages/sn-hooks-react/src/hooks/use-wopi.ts
+++ b/packages/sn-hooks-react/src/hooks/use-wopi.ts
@@ -13,7 +13,7 @@ export const useWopi = () => {
     (content: GenericContent) =>
       repo.schemas.isContentFromType(content, 'File') &&
       isActionModel(content.Actions) &&
-      content.Actions.some(action => action.Name === 'WopiOpenEdit'),
+      content.Actions.some(action => action.Name === 'WopiOpenEdit' && !action.Forbidden),
     [repo.schemas],
   )
 
@@ -22,7 +22,7 @@ export const useWopi = () => {
       isWriteAvailable(content) ||
       (repo.schemas.isContentFromType(content, 'File') &&
         isActionModel(content.Actions) &&
-        content.Actions.some(action => action.Name === 'WopiOpenView')),
+        content.Actions.some(action => action.Name === 'WopiOpenView' && !action.Forbidden)),
     [isWriteAvailable, repo.schemas],
   )
 


### PR DESCRIPTION
It is not enough to check the availability of the wopi actions in the /Actions response. Their Forbidden parameter could be true and in this cases they should be handled as they were unavailable.