### PR TITLE
Download action to the contextmenu

### DIFF
--- a/apps/sensenet/src/components/context-menu/content-context-menu.tsx
+++ b/apps/sensenet/src/components/context-menu/content-context-menu.tsx
@@ -44,6 +44,13 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
       }
       const contentActions = contentFromCallback.Actions.filter((action) => !action.Forbidden)
 
+      if (contentActions.findIndex((action) => action.Name === 'Browse' && props.content.IsFile)) {
+        contentActions.push({
+          Name: 'Download',
+          DisplayName: 'Download',
+        } as ActionModel)
+      }
+
       if (isWriteAvailable(contentFromCallback)) {
         // If write is available it means that we have two actions. We want to show only the open edit for the user.
         const actionsWithoutWopiRead = contentActions.filter((action) => action.Name !== 'WopiOpenView')

--- a/apps/sensenet/src/components/context-menu/content-context-menu.tsx
+++ b/apps/sensenet/src/components/context-menu/content-context-menu.tsx
@@ -43,8 +43,7 @@ export const ContentContextMenu: React.FunctionComponent<ContentContextMenuProps
         return
       }
       const contentActions = contentFromCallback.Actions.filter((action) => !action.Forbidden)
-
-      if (contentActions.findIndex((action) => action.Name === 'Browse' && props.content.IsFile)) {
+      if (contentActions.some((action) => action.Name === 'Browse') && contentFromCallback.IsFile) {
         contentActions.push({
           Name: 'Download',
           DisplayName: 'Download',

--- a/apps/sensenet/src/components/dashboard/markdown-widget.tsx
+++ b/apps/sensenet/src/components/dashboard/markdown-widget.tsx
@@ -12,7 +12,7 @@ export const MarkdownWidget: React.FunctionComponent<MarkdownWidgetModel> = (pro
     <>
       <Typography
         variant="h5"
-        title={props.title}
+        title={replacedTitle}
         gutterBottom={true}
         style={{ whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }}>
         {replacedTitle}

--- a/apps/sensenet/src/services/RepositoryManager.ts
+++ b/apps/sensenet/src/services/RepositoryManager.ts
@@ -22,6 +22,7 @@ export class RepositoryManager {
           'Type',
           'DisplayName',
           'Icon',
+          'IsFile',
           'IsFolder',
           'ParentId',
           'Version',

--- a/packages/sn-default-content-types/src/DefaultContentTypes.ts
+++ b/packages/sn-default-content-types/src/DefaultContentTypes.ts
@@ -94,6 +94,8 @@ export class GenericContent {
   public Depth?: number
   /* This field is true if content is in a system folder/trash or the content is a system folder/file. */
   public IsSystemContent?: boolean
+  /* This field is true if content the content is a file. */
+  public IsFile?: boolean
   /* This field is true if content can contain other content. */
   public IsFolder?: boolean
   /* Content name. You can set any name you prefer without any restrictions. */


### PR DESCRIPTION
Download action was missing from the context menu, because Browse action is now used on Files as metadata browse as on other types of content (in the old sensenet, the Browse action on Files was actually download).
I've added a statement to check if the Browse action is available and the content's type is file and then put the action Download to the context menu. The underlying logic, the actual download method was already there in the js client code.