### PR TITLE
Fix default value of rootPath on explore component

### DIFF
--- a/apps/sensenet/src/components/content/Explore.tsx
+++ b/apps/sensenet/src/components/content/Explore.tsx
@@ -57,7 +57,7 @@ export interface ExploreComponentProps {
   onNavigate: (newParent: GenericContent) => void
   onActivateItem: (item: GenericContent) => void
   fieldsToDisplay?: Array<keyof GenericContent>
-  rootPath?: string
+  rootPath: string
 }
 
 export const Explore: React.FunctionComponent<ExploreComponentProps> = (props) => {
@@ -68,10 +68,6 @@ export const Explore: React.FunctionComponent<ExploreComponentProps> = (props) =
   const [isFormOpened, setIsFormOpened] = useState(false)
   const [action, setAction] = useState<ActionNameType>(undefined)
   const repo = useRepository()
-
-  if (!props.rootPath) {
-    return null
-  }
 
   const setFormOpen = (actionName: ActionNameType) => {
     setAction(actionName)

--- a/apps/sensenet/src/components/content/index.tsx
+++ b/apps/sensenet/src/components/content/index.tsx
@@ -96,7 +96,7 @@ export const Content = () => {
         />
       ) : browseData.type === 'explorer' ? (
         <Explore
-          rootPath={browseData.root}
+          rootPath={browseData.root || ConstantContent.PORTAL_ROOT.Path}
           onNavigate={navigate}
           onActivateItem={openItem}
           parentIdOrPath={browseData.currentContent || browseData.root || ConstantContent.PORTAL_ROOT.Id}


### PR DESCRIPTION
Explore component rendered empty because rootPath was undefined.

- [x] Container item page render correctly