### PR TITLE
Base config for e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ jspm_packages/
 
 # Misc
 .DS_Store
+
+# Cypress realted videos
+cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "https://admin.test.sensenet.com"
+}

--- a/cypress/integration/example_test.js
+++ b/cypress/integration/example_test.js
@@ -1,0 +1,7 @@
+describe('Test site', () => {
+  it('visit the main page of the base url', () => {
+    cy.viewport(1602, 947)
+    cy.visit('/')
+    cy.xpath('/html/body/div[1]/div/div/div/div[1]/p[1]').contains('Welcome')
+  })
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,21 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+import 'cypress-xpath'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
     "babel-eslint": "10.1.0",
+    "cypress": "^4.5.0",
+    "cypress-xpath": "^1.4.0",
     "cz-conventional-changelog": "^3.1.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
@@ -52,7 +54,9 @@
     "clean:packages": "yarn build --clean",
     "test": "jest",
     "clean": "lerna clean",
-    "lint": "eslint . --ext .tsx,.ts --cache"
+    "lint": "eslint . --ext .tsx,.ts --cache",
+    "cypress": "cypress open",
+    "cypress:all": "cypress run"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7171,7 +7171,12 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^4.1.0:
+cypress-xpath@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cypress-xpath/-/cypress-xpath-1.4.0.tgz#0a7d1a8c59c263f01060d1d04a69f1b0337b06ff"
+  integrity sha512-rRSp3n48rycYkbUJc/n5uxcCUWwhdqufcw7SwkJS/R69NNC3tibCdPw46QuYk1V0KT/X/AY9p7VLIXWzNnm1TA==
+
+cypress@^4.1.0, cypress@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.5.0.tgz#01940d085f6429cec3c87d290daa47bb976a7c7b"
   integrity sha512-2A4g5FW5d2fHzq8HKUGAMVTnW6P8nlWYQALiCoGN4bqBLvgwhYM/oG9oKc2CS6LnvgHFiKivKzpm9sfk3uU3zQ==


### PR DESCRIPTION
### I have created the base config for cypress. 

We should create the e2e tests under cypress/integration folder.
Open GUI: `yarn cypress`
Run all test from terminal : `yarn cypress:all`

There is an example test under integration -> If you create a new, valid test you can remove this example. I have created it for the first try.

Cypress-xpath is imported in support/index, you can use it like: `cy.xpath('/html/body/div[1]/div/div/div/div[1]/p[1]')` in your tests.