### PR TITLE
Permission related redux actions

### DIFF
--- a/packages/sn-client-core/src/Repository/Security.ts
+++ b/packages/sn-client-core/src/Repository/Security.ts
@@ -54,7 +54,7 @@ export interface GetRelatedPermissionsOptions<TMemberType> {
    * Null means filtering off. If the array is empty, there is no element that increases the counters.
    * This filter can reduce the execution speed dramatically so do not use if it is possible.
    */
-  includedTypes?: string[]
+  includedTypes: string[] | null
   /**
    * Optional OData parameters
    */

--- a/packages/sn-client-core/src/Repository/Security.ts
+++ b/packages/sn-client-core/src/Repository/Security.ts
@@ -226,13 +226,13 @@ export class Security {
    * @param {PermissionRequestBody} permissionRequestBody inheritance: break or unbreak
    * @returns {Promise<PermissionResponseModel>} A promise with a response model
    */
-  public setPermissions = (idOrPath: string | number, permissionRequestBody: PermissionRequestBody) =>
-    this.repository.executeAction<{ r: PermissionRequestBody }, void>({
+  public setPermissions = (idOrPath: string | number, permissionRequestBody: PermissionRequestBody[]) =>
+    this.repository.executeAction<{ r: PermissionRequestBody[] }, void>({
       name: 'SetPermissions',
       idOrPath,
       method: 'POST',
       body: {
-        r: permissionRequestBody as PermissionRequestBody,
+        r: permissionRequestBody as PermissionRequestBody[],
       },
     })
 

--- a/packages/sn-client-core/src/Repository/Security.ts
+++ b/packages/sn-client-core/src/Repository/Security.ts
@@ -340,8 +340,8 @@ export class Security {
       idOrPath: options.contentIdOrPath,
       method: 'POST',
       body: {
-        level: options.level,
-        kind: options.kind,
+        permissionLevel: options.level,
+        indentityKind: options.kind,
       },
       oDataOptions: options.oDataOptions,
     })
@@ -359,9 +359,9 @@ export class Security {
       idOrPath: options.contentIdOrPath,
       method: 'POST',
       body: {
-        level: options.level,
+        permissionLevel: options.level,
         explicitOnly: options.explicitOnly,
-        member: options.memberPath,
+        memberPath: options.memberPath,
         includedTypes: options.includedTypes,
       },
       oDataOptions: options.oDataOptions,
@@ -378,9 +378,9 @@ export class Security {
       idOrPath: options.contentIdOrPath,
       method: 'POST',
       body: {
-        level: options.level,
+        permissionLevel: options.level,
         explicitOnly: options.explicitOnly,
-        member: options.member,
+        memberPath: options.member,
         permissions: options.permissions,
       },
       oDataOptions: options.oDataOptions,
@@ -400,8 +400,8 @@ export class Security {
       idOrPath: options.contentIdOrPath,
       method: 'POST',
       body: {
-        level: options.level,
-        kind: options.kind,
+        permissionLevel: options.level,
+        identityKind: options.kind,
         permissions: options.permissions,
       },
       oDataOptions: options.oDataOptions,
@@ -418,8 +418,8 @@ export class Security {
       idOrPath: options.contentIdOrPath,
       method: 'POST',
       body: {
-        level: options.level,
-        member: options.member,
+        permissionLevel: options.level,
+        memberPath: options.member,
         permissions: options.permissions,
       },
       oDataOptions: options.oDataOptions,

--- a/packages/sn-client-core/src/Repository/Security.ts
+++ b/packages/sn-client-core/src/Repository/Security.ts
@@ -1,12 +1,5 @@
 import { PathHelper } from '@sensenet/client-utils'
-import {
-  Group,
-  IdentityKind,
-  Inheritance,
-  PermissionLevel,
-  PermissionRequestBody,
-  User,
-} from '@sensenet/default-content-types'
+import { Group, IdentityKind, PermissionLevel, PermissionRequestBody, User } from '@sensenet/default-content-types'
 import { Content, PermissionEntry } from '../index'
 import { ODataCollectionResponse } from '../Models/ODataCollectionResponse'
 import { ODataParams } from '../Models/ODataParams'
@@ -202,22 +195,6 @@ export interface GetParentGroupsOptions<T> {
  */
 export class Security {
   constructor(private readonly repository: Repository) {}
-
-  /**
-   * Sets permission inheritance on the requested content.
-   * @param {string | number} idOrPath A content id or path
-   * @param {Inheritance} inheritance inheritance: break or unbreak
-   * @returns {Promise<PermissionResponseModel>} A promise with a response model
-   */
-  public setPermissionInheritance = (idOrPath: string | number, inheritance: Inheritance) =>
-    this.repository.executeAction<{ r: Inheritance }, void>({
-      name: 'SetPermissions',
-      idOrPath,
-      method: 'POST',
-      body: {
-        r: inheritance as Inheritance,
-      },
-    })
 
   /**
    * Sets permissions on the requested content.

--- a/packages/sn-client-core/test/security.test.ts
+++ b/packages/sn-client-core/test/security.test.ts
@@ -15,16 +15,36 @@ describe('Security', () => {
     repository.dispose()
   })
 
-  it('Should execute setPermissionInheritance', () => {
-    expect(security.setPermissionInheritance(1, Inheritance.Break)).toBeInstanceOf(Promise)
-  })
-
   it('Should execute setPermissions', () => {
     expect(
       security.setPermissions(1, [
         {
           AddNew: PermissionValues.allow,
           identity: 'root/users/user1',
+        },
+      ]),
+    ).toBeInstanceOf(Promise)
+  })
+
+  it('Should execute setPermissions with break', () => {
+    expect(
+      security.setPermissions(1, [
+        {
+          AddNew: PermissionValues.allow,
+          identity: 'root/users/user1',
+          inheritance: Inheritance.Break,
+        },
+      ]),
+    ).toBeInstanceOf(Promise)
+  })
+
+  it('Should execute setPermissions locally', () => {
+    expect(
+      security.setPermissions(1, [
+        {
+          AddNew: PermissionValues.allow,
+          identity: 'root/users/user1',
+          localOnly: true,
         },
       ]),
     ).toBeInstanceOf(Promise)

--- a/packages/sn-client-core/test/security.test.ts
+++ b/packages/sn-client-core/test/security.test.ts
@@ -21,10 +21,12 @@ describe('Security', () => {
 
   it('Should execute setPermissions', () => {
     expect(
-      security.setPermissions(1, {
-        AddNew: PermissionValues.allow,
-        identity: 'root/users/user1',
-      }),
+      security.setPermissions(1, [
+        {
+          AddNew: PermissionValues.allow,
+          identity: 'root/users/user1',
+        },
+      ]),
     ).toBeInstanceOf(Promise)
   })
 

--- a/packages/sn-default-content-types/src/Security.ts
+++ b/packages/sn-default-content-types/src/Security.ts
@@ -24,6 +24,7 @@ export enum PermissionLevel {
 export class PermissionRequestBody {
   public identity!: string
   public localOnly?: boolean
+  public inheritance?: Inheritance
   public RestrictedPreview?: PermissionValues
   public PreviewWithoutWatermakr?: PermissionValues
   public PreviewWithoutRedaction?: PermissionValues

--- a/packages/sn-redux/src/Actions.ts
+++ b/packages/sn-redux/src/Actions.ts
@@ -115,6 +115,13 @@ import { GoogleOauthProvider } from '@sensenet/authentication-google'
 import {
   CommentWithoutCreatedByAndId,
   Content,
+  GetAllowedUsersOptions,
+  GetParentGroupsOptions,
+  GetRelatedIdentities,
+  GetRelatedIdentitiesByPermissions,
+  GetRelatedItemsOneLevel,
+  GetRelatedItemsOptions,
+  GetRelatedPermissionsOptions,
   LoginState,
   ODataFieldParameter,
   ODataParams,
@@ -123,7 +130,7 @@ import {
   SharingOptions,
 } from '@sensenet/client-core'
 import { PathHelper } from '@sensenet/client-utils'
-import { FieldSetting, GenericContent, PermissionRequestBody, User } from '@sensenet/default-content-types'
+import { FieldSetting, GenericContent, Group, PermissionRequestBody, User } from '@sensenet/default-content-types'
 import { PromiseMiddlewareAction } from '@sensenet/redux-promise-middleware'
 
 /**
@@ -909,4 +916,67 @@ export const getPermissions = (idOrPath: string | number, identity?: string) => 
 export const setPermissions = (idOrPath: string | number, permissions: PermissionRequestBody[]) => ({
   type: 'SET_PERMISSIONS',
   payload: (repository: Repository) => repository.security.setPermissions(idOrPath, permissions),
+})
+
+/**
+ * Action creator for get allowed users on a content
+ * @param options user and permission options
+ */
+export const getAllowedUsers = (options: GetAllowedUsersOptions<User>) => ({
+  type: 'GET_ALLOWED_USERS',
+  payload: (repository: Repository) => repository.security.getAllowedUsers(options),
+})
+
+/**
+ * Action creator for get parent groups of a content
+ * @param options user and permission options
+ */
+export const getParentGroups = (options: GetParentGroupsOptions<Group>) => ({
+  type: 'GET_PARENT_GROUPS',
+  payload: (repository: Repository) => repository.security.getParentGroups(options),
+})
+
+/**
+ * Action creator for get related identites
+ * @param options user or group options
+ */
+export const getRelatedIdentities = (options: GetRelatedIdentities<User | Group>) => ({
+  type: 'GET_RELATED_IDENTITIES',
+  payload: (repository: Repository) => repository.security.getRelatedIdentities(options),
+})
+
+/**
+ * Action creator for get related identites by permissions
+ * @param options user or group options
+ */
+export const getRelatedIdentitiesByPermissions = (options: GetRelatedIdentitiesByPermissions<User | Group>) => ({
+  type: 'GET_RELATED_IDENTITIES_BY_PERMISSONS',
+  payload: (repository: Repository) => repository.security.getRelatedIdentitiesByPermissions(options),
+})
+
+/**
+ * Action creator for get related items
+ * @param options content options
+ */
+export const getRelatedItems = (options: GetRelatedItemsOptions<GenericContent>) => ({
+  type: 'GET_RELATED_ITEMS',
+  payload: (repository: Repository) => repository.security.getRelatedItems(options),
+})
+
+/**
+ * Action creator for get related items one level
+ * @param options content options
+ */
+export const getRelatedItemsOneLevel = (options: GetRelatedItemsOneLevel<GenericContent>) => ({
+  type: 'GET_RELATED_ITEMS_ONE_LEVEL',
+  payload: (repository: Repository) => repository.security.getRelatedItemsOneLevel(options),
+})
+
+/**
+ * Action creator for get related permissions
+ * @param options content options
+ */
+export const getRelatedPermissions = (options: GetRelatedPermissionsOptions<GenericContent>) => ({
+  type: 'GET_RELATED_PERMISSIONS',
+  payload: (repository: Repository) => repository.security.getRelatedPermissions(options),
 })

--- a/packages/sn-redux/src/Actions.ts
+++ b/packages/sn-redux/src/Actions.ts
@@ -906,7 +906,7 @@ export const getPermissions = (idOrPath: string | number, identity?: string) => 
  * @param permissions permission request body
  */
 
-export const setPermissions = (idOrPath: string | number, permissions: PermissionRequestBody) => ({
+export const setPermissions = (idOrPath: string | number, permissions: PermissionRequestBody[]) => ({
   type: 'SET_PERMISSIONS',
   payload: (repository: Repository) => repository.security.setPermissions(idOrPath, permissions),
 })

--- a/packages/sn-redux/src/Actions.ts
+++ b/packages/sn-redux/src/Actions.ts
@@ -123,7 +123,7 @@ import {
   SharingOptions,
 } from '@sensenet/client-core'
 import { PathHelper } from '@sensenet/client-utils'
-import { FieldSetting, GenericContent, User } from '@sensenet/default-content-types'
+import { FieldSetting, GenericContent, PermissionRequestBody, User } from '@sensenet/default-content-types'
 import { PromiseMiddlewareAction } from '@sensenet/redux-promise-middleware'
 
 /**
@@ -898,4 +898,15 @@ export const getPermissions = (idOrPath: string | number, identity?: string) => 
     identity
       ? repository.security.getPermissionsForIdentity(idOrPath, identity)
       : repository.security.getAllPermissions(idOrPath),
+})
+
+/**
+ * Action creator for set permissions on a content
+ * @param idOrPath Id or Path of the content
+ * @param permissions permission request body
+ */
+
+export const setPermissions = (idOrPath: string | number, permissions: PermissionRequestBody) => ({
+  type: 'SET_PERMISSIONS',
+  payload: (repository: Repository) => repository.security.setPermissions(idOrPath, permissions),
 })

--- a/packages/sn-redux/src/Actions.ts
+++ b/packages/sn-redux/src/Actions.ts
@@ -819,3 +819,83 @@ export const deleteListField = (idOrPath: number | string) => ({
       method: 'POST',
     }),
 })
+
+/**
+ * Action creator for check whether the given identity has the given permissions
+ * @param idOrPath Id or Path of the content
+ * @param permissions List of permissions that should be checked
+ * @param identityPath Path of the identity
+ */
+export const hasPermission = (
+  idOrPath: number | string,
+  permissions: Array<
+    | 'See'
+    | 'Preview'
+    | 'PreviewWithoutWatermark'
+    | 'PreviewWithoutRedaction'
+    | 'Open'
+    | 'OpenMinor'
+    | 'Save'
+    | 'Publish'
+    | 'ForceCheckin'
+    | 'AddNew'
+    | 'Approve'
+    | 'Delete'
+    | 'RecallOldVersion'
+    | 'DeleteOldVersion'
+    | 'SeePermissions'
+    | 'SetPermissions'
+    | 'RunApplication'
+    | 'ManageListsAndWorkspaces'
+    | 'TakeOwnership'
+    | 'Custom01'
+    | 'Custom02'
+    | 'Custom03'
+    | 'Custom04'
+    | 'Custom05'
+    | 'Custom06'
+    | 'Custom07'
+    | 'Custom08'
+    | 'Custom09'
+    | 'Custom10'
+    | 'Custom11'
+    | 'Custom12'
+    | 'Custom13'
+    | 'Custom14'
+    | 'Custom15'
+    | 'Custom16'
+    | 'Custom17'
+    | 'Custom18'
+    | 'Custom19'
+    | 'Custom20'
+    | 'Custom21'
+    | 'Custom22'
+    | 'Custom23'
+    | 'Custom24'
+    | 'Custom25'
+    | 'Custom26'
+    | 'Custom27'
+    | 'Custom28'
+    | 'Custom29'
+    | 'Custom30'
+    | 'Custom31'
+    | 'Custom32'
+  >,
+  identityPath?: string,
+) => ({
+  type: 'HAS_PERMISSION',
+  payload: (repository: Repository) => repository.security.hasPermission(idOrPath, permissions, identityPath),
+})
+
+/**
+ * Action creator for get all permission settings for a content
+ * @param idOrPath Id or Path of the content
+ * @param identity Path of the identity
+ */
+export const getPermissions = (idOrPath: string | number, identity?: string) => ({
+  type: 'GET_PERMISSIONS',
+  payload: (repository: Repository) =>
+    identity
+      ? repository.security.getPermissionsForIdentity(idOrPath, identity)
+      : repository.security.getAllPermissions(idOrPath),
+})

--- a/packages/sn-redux/test/actions.test.ts
+++ b/packages/sn-redux/test/actions.test.ts
@@ -243,6 +243,13 @@ const contentTypeCollectionMockResponse = {
   },
 } as Response
 
+const hasPermissionMockResponse = {
+  ok: true,
+  status: 200,
+  json: async () => true,
+  text: async () => 'true',
+} as Response
+
 describe('Actions', () => {
   const path = '/workspaces/project'
   let repo: Repository
@@ -1562,6 +1569,40 @@ describe('Actions', () => {
         })
         it('should return mockdata', () => {
           expect(data).toBeUndefined()
+        })
+      })
+    })
+  })
+  describe('hasPermission', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => hasPermissionMockResponse)
+    })
+    describe('Action types are types', () => {
+      expect(Actions.hasPermission(path, ['Open']).type).toBe('HAS_PERMISSION')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.hasPermission(path, ['Open']).payload(repo)
+      })
+      describe('Given repository.hasPermission() resolves', () => {
+        it('should return a HAS_PERMISSION action', () => {
+          expect(Actions.hasPermission(path, ['Open'])).toHaveProperty('type', 'HAS_PERMISSION')
+        })
+        it('should return mockdata', () => {
+          expect(data).toBeTruthy()
+        })
+      })
+      describe('Given repository.hasPermission() resolves with identity', () => {
+        it('should return a HAS_PERMISSION action', () => {
+          expect(Actions.hasPermission(path, ['Open'], '/Root/IMS/Public/devdog')).toHaveProperty(
+            'type',
+            'HAS_PERMISSION',
+          )
+        })
+        it('should return mockdata', () => {
+          expect(data).toBeTruthy()
         })
       })
     })

--- a/packages/sn-redux/test/actions.test.ts
+++ b/packages/sn-redux/test/actions.test.ts
@@ -11,7 +11,14 @@ import {
   SharingLevel,
   SharingMode,
 } from '@sensenet/client-core'
-import { ActionModel, GenericContent, Task, User } from '@sensenet/default-content-types'
+import {
+  ActionModel,
+  GenericContent,
+  PermissionRequestBody,
+  PermissionValues,
+  Task,
+  User,
+} from '@sensenet/default-content-types'
 import * as Actions from '../src/Actions'
 
 const jwtMockResponse = {
@@ -1809,6 +1816,37 @@ describe('Actions', () => {
         })
         it('should return mockdata', () => {
           expect(data.response.entries.length).toBeGreaterThan(0)
+        })
+      })
+    })
+  })
+  describe('setPermissions', () => {
+    const permissions = [
+      {
+        identity: '/Root/IMS/Public/Editors',
+        localOnly: true,
+        AddNew: PermissionValues.allow,
+      } as PermissionRequestBody,
+    ]
+
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => emptyResponse)
+    })
+    describe('Action types are types', () => {
+      expect(Actions.setPermissions(path, permissions).type).toBe('SET_PERMISSIONS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.setPermissions(path, permissions).payload(repo)
+      })
+      describe('Given repository.setPermissions() resolves', () => {
+        it('should return a SET_PERMISSION action', () => {
+          expect(Actions.setPermissions(path, permissions)).toHaveProperty('type', 'SET_PERMISSIONS')
+        })
+        it('should return mockdata', () => {
+          expect(data).toBeUndefined()
         })
       })
     })

--- a/packages/sn-redux/test/actions.test.ts
+++ b/packages/sn-redux/test/actions.test.ts
@@ -250,6 +250,181 @@ const hasPermissionMockResponse = {
   text: async () => 'true',
 } as Response
 
+const getPermissionsMockResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return {
+      content: {
+        Id: 1225,
+        Path: '/Root/Content/Marketing',
+        Name: 'Marketing',
+      },
+      action: 'GetPermissions',
+      response: {
+        id: 1225,
+        path: '/Root/Content/Marketing',
+        inherits: true,
+        entries: [
+          {
+            identity: {
+              id: 7,
+              path: '/Root/IMS/BuiltIn/Portal/Administrators',
+              name: 'Administrators',
+              displayName: 'Administrators',
+              domain: null,
+              kind: 'group',
+            },
+            propagates: true,
+            permissions: {
+              See: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Preview: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              PreviewWithoutWatermark: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              PreviewWithoutRedaction: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Open: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              OpenMinor: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Save: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Publish: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              ForceCheckin: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              AddNew: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Approve: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Delete: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              RecallOldVersion: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              DeleteOldVersion: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              SeePermissions: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              SetPermissions: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              RunApplication: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              ManageListsAndWorkspaces: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              TakeOwnership: {
+                value: 'allow',
+                from: '/Root/Content',
+                identity: '/Root/IMS/BuiltIn/Portal/Administrators',
+              },
+              Unused13: null,
+              Unused12: null,
+              Unused11: null,
+              Unused10: null,
+              Unused09: null,
+              Unused08: null,
+              Unused07: null,
+              Unused06: null,
+              Unused05: null,
+              Unused04: null,
+              Unused03: null,
+              Unused02: null,
+              Unused01: null,
+              Custom01: null,
+              Custom02: null,
+              Custom03: null,
+              Custom04: null,
+              Custom05: null,
+              Custom06: null,
+              Custom07: null,
+              Custom08: null,
+              Custom09: null,
+              Custom10: null,
+              Custom11: null,
+              Custom12: null,
+              Custom13: null,
+              Custom14: null,
+              Custom15: null,
+              Custom16: null,
+              Custom17: null,
+              Custom18: null,
+              Custom19: null,
+              Custom20: null,
+              Custom21: null,
+              Custom22: null,
+              Custom23: null,
+              Custom24: null,
+              Custom25: null,
+              Custom26: null,
+              Custom27: null,
+              Custom28: null,
+              Custom29: null,
+              Custom30: null,
+              Custom31: null,
+              Custom32: null,
+            },
+          },
+        ],
+      },
+    }
+  },
+} as Response
+
 describe('Actions', () => {
   const path = '/workspaces/project'
   let repo: Repository
@@ -1603,6 +1778,37 @@ describe('Actions', () => {
         })
         it('should return mockdata', () => {
           expect(data).toBeTruthy()
+        })
+      })
+    })
+  })
+  describe('getPermission', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => getPermissionsMockResponse)
+    })
+    describe('Action types are types', () => {
+      expect(Actions.getPermissions(path).type).toBe('GET_PERMISSIONS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getPermissions(path).payload(repo)
+      })
+      describe('Given repository.getPermissions() resolves', () => {
+        it('should return a GET_PERMISSIONS action', () => {
+          expect(Actions.getPermissions(path)).toHaveProperty('type', 'GET_PERMISSIONS')
+        })
+        it('should return mockdata', () => {
+          expect(data.response.entries.length).toBeGreaterThan(0)
+        })
+      })
+      describe('Given repository.getPermissions() resolves with identity', () => {
+        it('should return a GET_PERMISSIONS action', () => {
+          expect(Actions.getPermissions(path, '/Root/IMS/Public/devdog')).toHaveProperty('type', 'GET_PERMISSIONS')
+        })
+        it('should return mockdata', () => {
+          expect(data.response.entries.length).toBeGreaterThan(0)
         })
       })
     })

--- a/packages/sn-redux/test/actions.test.ts
+++ b/packages/sn-redux/test/actions.test.ts
@@ -14,6 +14,8 @@ import {
 import {
   ActionModel,
   GenericContent,
+  IdentityKind,
+  PermissionLevel,
   PermissionRequestBody,
   PermissionValues,
   Task,
@@ -262,12 +264,6 @@ const getPermissionsMockResponse = {
   status: 200,
   json: async () => {
     return {
-      content: {
-        Id: 1225,
-        Path: '/Root/Content/Marketing',
-        Name: 'Marketing',
-      },
-      action: 'GetPermissions',
       response: {
         id: 1225,
         path: '/Root/Content/Marketing',
@@ -428,6 +424,485 @@ const getPermissionsMockResponse = {
           },
         ],
       },
+    }
+  },
+} as Response
+
+const allowedUsersResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return {
+      d: {
+        __count: 4,
+        results: [
+          {
+            Id: 1,
+            Path: '/Root/IMS/BuiltIn/Portal/Admin',
+            Name: 'Admin',
+            Type: 'User',
+            DisplayName: 'Admin',
+            Icon: 'User',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:21.5405437Z',
+            Avatar: {
+              Url: '',
+            },
+            Description: null,
+          },
+          {
+            Id: 1141,
+            Path: '/Root/IMS/BuiltIn/Portal/previewadmin',
+            Name: 'previewadmin',
+            Type: 'User',
+            DisplayName: 'Preview Admin',
+            Icon: 'User',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:43.05Z',
+            Avatar: {
+              Url: '',
+            },
+            Description: null,
+          },
+          {
+            Id: 1154,
+            Path: '/Root/IMS/Public/businesscat',
+            Name: 'businesscat',
+            Type: 'User',
+            DisplayName: 'Business Cat',
+            Icon: 'User',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:49.42Z',
+            Avatar: {
+              Url: '/Root/Content/demoavatars/businesscat.jpeg',
+            },
+            Description: null,
+          },
+          {
+            Id: 1157,
+            Path: '/Root/IMS/Public/editormanatee',
+            Name: 'editormanatee',
+            Type: 'User',
+            DisplayName: 'Editor Manatee',
+            Icon: 'User',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:50.6Z',
+            Avatar: {
+              Url: '/Root/Content/demoavatars/editormanatee.jpg',
+            },
+            Description: null,
+          },
+        ],
+      },
+    }
+  },
+} as Response
+
+const parentGroupResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return {
+      d: {
+        __count: 1,
+        results: [
+          {
+            Id: 1152,
+            Path: '/Root/IMS/Public/Administrators',
+            Name: 'Administrators',
+            Type: 'Group',
+            DisplayName: 'Administrators',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:48.81Z',
+            Avatar: null,
+            Description: 'Members of this group have full access.',
+          },
+        ],
+      },
+    }
+  },
+} as Response
+
+const relatedIdentitiesResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return {
+      d: {
+        __count: 8,
+        results: [
+          {
+            Id: 1178,
+            Path: '/Root/Content/IT/Groups/Members',
+            Name: 'Members',
+            Type: 'Group',
+            DisplayName: 'Members',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1177,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2012-10-25T16:44:17.143Z',
+            Avatar: null,
+            Description: '',
+          },
+          {
+            Id: 1179,
+            Path: '/Root/Content/IT/Groups/Owners',
+            Name: 'Owners',
+            Type: 'Group',
+            DisplayName: 'Owners',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1177,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:59.94Z',
+            Avatar: null,
+            Description: null,
+          },
+          {
+            Id: 1180,
+            Path: '/Root/Content/IT/Groups/Visitors',
+            Name: 'Visitors',
+            Type: 'Group',
+            DisplayName: 'Visitors',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1177,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2012-10-25T16:44:17.19Z',
+            Avatar: null,
+            Description: '',
+          },
+          {
+            Id: 6,
+            Path: '/Root/IMS/BuiltIn/Portal/Visitor',
+            Name: 'Visitor',
+            Type: 'User',
+            DisplayName: 'Visitor',
+            Icon: 'User',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:21.5405437Z',
+            Avatar: {
+              Url: '',
+            },
+            Description: null,
+          },
+          {
+            Id: 7,
+            Path: '/Root/IMS/BuiltIn/Portal/Administrators',
+            Name: 'Administrators',
+            Type: 'Group',
+            DisplayName: 'Administrators',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:21.5405437Z',
+            Avatar: null,
+            Description: null,
+          },
+          {
+            Id: 1152,
+            Path: '/Root/IMS/Public/Administrators',
+            Name: 'Administrators',
+            Type: 'Group',
+            DisplayName: 'Administrators',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:48.81Z',
+            Avatar: null,
+            Description: 'Members of this group have full access.',
+          },
+          {
+            Id: 1158,
+            Path: '/Root/IMS/Public/Editors',
+            Name: 'Editors',
+            Type: 'Group',
+            DisplayName: 'Editors',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:51.18Z',
+            Avatar: null,
+            Description: 'Members of this groups can manage content items, build and save custom search queries.',
+          },
+          {
+            Id: 8,
+            Path: '/Root/IMS/BuiltIn/Portal/Everyone',
+            Name: 'Everyone',
+            Type: 'Group',
+            DisplayName: 'Everyone',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:21.5405437Z',
+            Avatar: null,
+            Description: null,
+          },
+        ],
+      },
+    }
+  },
+} as Response
+
+const relatedItemsResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return {
+      d: {
+        __count: 7,
+        results: [
+          {
+            Id: 1178,
+            Path: '/Root/Content/IT/Groups/Members',
+            Name: 'Members',
+            Type: 'Group',
+            DisplayName: 'Members',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1177,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2012-10-25T16:44:17.143Z',
+            Avatar: null,
+            Description: '',
+          },
+          {
+            Id: 1179,
+            Path: '/Root/Content/IT/Groups/Owners',
+            Name: 'Owners',
+            Type: 'Group',
+            DisplayName: 'Owners',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1177,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:59.94Z',
+            Avatar: null,
+            Description: null,
+          },
+          {
+            Id: 1180,
+            Path: '/Root/Content/IT/Groups/Visitors',
+            Name: 'Visitors',
+            Type: 'Group',
+            DisplayName: 'Visitors',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1177,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2012-10-25T16:44:17.19Z',
+            Avatar: null,
+            Description: '',
+          },
+          {
+            Id: 7,
+            Path: '/Root/IMS/BuiltIn/Portal/Administrators',
+            Name: 'Administrators',
+            Type: 'Group',
+            DisplayName: 'Administrators',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:21.5405437Z',
+            Avatar: null,
+            Description: null,
+          },
+          {
+            Id: 1152,
+            Path: '/Root/IMS/Public/Administrators',
+            Name: 'Administrators',
+            Type: 'Group',
+            DisplayName: 'Administrators',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:48.81Z',
+            Avatar: null,
+            Description: 'Members of this group have full access.',
+          },
+          {
+            Id: 1158,
+            Path: '/Root/IMS/Public/Editors',
+            Name: 'Editors',
+            Type: 'Group',
+            DisplayName: 'Editors',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 1109,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:51.18Z',
+            Avatar: null,
+            Description: 'Members of this groups can manage content items, build and save custom search queries.',
+          },
+          {
+            Id: 8,
+            Path: '/Root/IMS/BuiltIn/Portal/Everyone',
+            Name: 'Everyone',
+            Type: 'Group',
+            DisplayName: 'Everyone',
+            Icon: 'Group',
+            IsFile: false,
+            IsFolder: false,
+            ParentId: 5,
+            Version: 'V1.0.A',
+            PageCount: null,
+            Binary: null,
+            CreationDate: '2020-06-23T01:03:21.5405437Z',
+            Avatar: null,
+            Description: null,
+          },
+        ],
+      },
+    }
+  },
+} as Response
+
+const relatedPermissionsResponse = {
+  ok: true,
+  status: 200,
+  json: async () => {
+    return {
+      See: 0,
+      Preview: 0,
+      PreviewWithoutWatermark: 0,
+      PreviewWithoutRedaction: 0,
+      Open: 0,
+      OpenMinor: 0,
+      Save: 0,
+      Publish: 0,
+      ForceCheckin: 0,
+      AddNew: 0,
+      Approve: 0,
+      Delete: 0,
+      RecallOldVersion: 0,
+      DeleteOldVersion: 0,
+      SeePermissions: 0,
+      SetPermissions: 0,
+      RunApplication: 0,
+      ManageListsAndWorkspaces: 0,
+      TakeOwnership: 0,
+      Unused13: 0,
+      Unused12: 0,
+      Unused11: 0,
+      Unused10: 0,
+      Unused09: 0,
+      Unused08: 0,
+      Unused07: 0,
+      Unused06: 0,
+      Unused05: 0,
+      Unused04: 0,
+      Unused03: 0,
+      Unused02: 0,
+      Unused01: 0,
+      Custom01: 0,
+      Custom02: 0,
+      Custom03: 0,
+      Custom04: 0,
+      Custom05: 0,
+      Custom06: 0,
+      Custom07: 0,
+      Custom08: 0,
+      Custom09: 0,
+      Custom10: 0,
+      Custom11: 0,
+      Custom12: 0,
+      Custom13: 0,
+      Custom14: 0,
+      Custom15: 0,
+      Custom16: 0,
+      Custom17: 0,
+      Custom18: 0,
+      Custom19: 0,
+      Custom20: 0,
+      Custom21: 0,
+      Custom22: 0,
+      Custom23: 0,
+      Custom24: 0,
+      Custom25: 0,
+      Custom26: 0,
+      Custom27: 0,
+      Custom28: 0,
+      Custom29: 0,
+      Custom30: 0,
+      Custom31: 0,
+      Custom32: 0,
     }
   },
 } as Response
@@ -1847,6 +2322,266 @@ describe('Actions', () => {
         })
         it('should return mockdata', () => {
           expect(data).toBeUndefined()
+        })
+      })
+    })
+  })
+  describe('getAllowedUsers', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => allowedUsersResponse)
+    })
+    describe('Action types are types', () => {
+      expect(Actions.getAllowedUsers({ contentIdOrPath: 1, permissions: ['Open'] }).type).toBe('GET_ALLOWED_USERS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getAllowedUsers({ contentIdOrPath: 1, permissions: ['Open'] }).payload(repo)
+      })
+      describe('Given repository.getAllowedUsers() resolves', () => {
+        it('should return a GET_ALLOWED_USERS action', () => {
+          expect(Actions.getAllowedUsers({ contentIdOrPath: 1, permissions: ['Open'] })).toHaveProperty(
+            'type',
+            'GET_ALLOWED_USERS',
+          )
+        })
+        it('should return mockdata', () => {
+          expect(data.d.__count).toBe(4)
+        })
+      })
+    })
+  })
+  describe('getParentGroups', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => parentGroupResponse)
+    })
+    describe('Action types are types', () => {
+      expect(Actions.getParentGroups({ contentIdOrPath: 1, directOnly: true }).type).toBe('GET_PARENT_GROUPS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getParentGroups({ contentIdOrPath: 1, directOnly: true }).payload(repo)
+      })
+      describe('Given repository.getParentGroups() resolves', () => {
+        it('should return a GET_PARENT_GROUPS action', () => {
+          expect(Actions.getParentGroups({ contentIdOrPath: 1, directOnly: true })).toHaveProperty(
+            'type',
+            'GET_PARENT_GROUPS',
+          )
+        })
+        it('should return mockdata', () => {
+          expect(data.d.__count).toBe(1)
+        })
+      })
+    })
+  })
+
+  describe('getRelatedIdentities', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => relatedIdentitiesResponse)
+    })
+    describe('Action types are types', () => {
+      expect(
+        Actions.getRelatedIdentities({ contentIdOrPath: 1, kind: IdentityKind.All, level: PermissionLevel.Allowed })
+          .type,
+      ).toBe('GET_RELATED_IDENTITIES')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getRelatedIdentities({
+          contentIdOrPath: 1,
+          kind: IdentityKind.All,
+          level: PermissionLevel.Allowed,
+        }).payload(repo)
+      })
+      describe('Given repository.getRelatedIdentities() resolves', () => {
+        it('should return a GET_RELATED_IDENTITIES action', () => {
+          expect(
+            Actions.getRelatedIdentities({
+              contentIdOrPath: 1,
+              kind: IdentityKind.All,
+              level: PermissionLevel.Allowed,
+            }),
+          ).toHaveProperty('type', 'GET_RELATED_IDENTITIES')
+        })
+        it('should return mockdata', () => {
+          expect(data.d.__count).toBe(8)
+        })
+      })
+    })
+  })
+  describe('getRelatedIdentitiesByPermissions', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => relatedIdentitiesResponse)
+    })
+    describe('Action types are types', () => {
+      expect(
+        Actions.getRelatedIdentitiesByPermissions({
+          contentIdOrPath: 1,
+          kind: IdentityKind.All,
+          level: PermissionLevel.Allowed,
+          permissions: ['Save'],
+        }).type,
+      ).toBe('GET_RELATED_IDENTITIES_BY_PERMISSONS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getRelatedIdentitiesByPermissions({
+          contentIdOrPath: 1,
+          kind: IdentityKind.All,
+          level: PermissionLevel.Allowed,
+          permissions: ['Save'],
+        }).payload(repo)
+      })
+      describe('Given repository.getRelatedIdentitiesByPermissions() resolves', () => {
+        it('should return a GET_RELATED_IDENTITIES_BY_PERMISSONS action', () => {
+          expect(
+            Actions.getRelatedIdentitiesByPermissions({
+              contentIdOrPath: 1,
+              kind: IdentityKind.All,
+              level: PermissionLevel.Allowed,
+              permissions: ['Save'],
+            }),
+          ).toHaveProperty('type', 'GET_RELATED_IDENTITIES_BY_PERMISSONS')
+        })
+        it('should return mockdata', () => {
+          expect(data.d.__count).toBe(8)
+        })
+      })
+    })
+  })
+  describe('getRelatedItems', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => relatedItemsResponse)
+    })
+    describe('Action types are types', () => {
+      expect(
+        Actions.getRelatedItems({
+          contentIdOrPath: 1,
+          level: PermissionLevel.Allowed,
+          permissions: ['Save'],
+          explicitOnly: true,
+          member: '/Root/IMS/Public/Editors',
+        }).type,
+      ).toBe('GET_RELATED_ITEMS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getRelatedItems({
+          contentIdOrPath: 1,
+          level: PermissionLevel.Allowed,
+          permissions: ['Save'],
+          explicitOnly: true,
+          member: '/Root/IMS/Public/Editors',
+        }).payload(repo)
+      })
+      describe('Given repository.getRelatedItems() resolves', () => {
+        it('should return a GET_RELATED_ITEMS action', () => {
+          expect(
+            Actions.getRelatedItems({
+              contentIdOrPath: 1,
+              level: PermissionLevel.Allowed,
+              permissions: ['Save'],
+              explicitOnly: true,
+              member: '/Root/IMS/Public/Editors',
+            }),
+          ).toHaveProperty('type', 'GET_RELATED_ITEMS')
+        })
+        it('should return mockdata', () => {
+          expect(data.d.__count).toBe(7)
+        })
+      })
+    })
+  })
+  describe('getRelatedItemsOneLevel', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => relatedItemsResponse)
+    })
+    describe('Action types are types', () => {
+      expect(
+        Actions.getRelatedItemsOneLevel({
+          contentIdOrPath: 1,
+          level: PermissionLevel.Allowed,
+          permissions: ['Save'],
+          member: '/Root/IMS/Public/Editors',
+        }).type,
+      ).toBe('GET_RELATED_ITEMS_ONE_LEVEL')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getRelatedItemsOneLevel({
+          contentIdOrPath: 1,
+          level: PermissionLevel.Allowed,
+          permissions: ['Save'],
+          member: '/Root/IMS/Public/Editors',
+        }).payload(repo)
+      })
+      describe('Given repository.getRelatedItemsOneLevel() resolves', () => {
+        it('should return a GET_RELATED_ITEMS_ONE_LEVEL action', () => {
+          expect(
+            Actions.getRelatedItemsOneLevel({
+              contentIdOrPath: 1,
+              level: PermissionLevel.Allowed,
+              permissions: ['Save'],
+              member: '/Root/IMS/Public/Editors',
+            }),
+          ).toHaveProperty('type', 'GET_RELATED_ITEMS_ONE_LEVEL')
+        })
+        it('should return mockdata', () => {
+          expect(data.d.__count).toBe(7)
+        })
+      })
+    })
+  })
+  describe('getRelatedPermissions', () => {
+    beforeEach(() => {
+      repo = new Repository({ repositoryUrl: 'https://dev.demo.sensenet.com/' }, async () => relatedPermissionsResponse)
+    })
+    describe('Action types are types', () => {
+      expect(
+        Actions.getRelatedPermissions({
+          contentIdOrPath: 1,
+          level: PermissionLevel.Allowed,
+          explicitOnly: true,
+          memberPath: '/Root/IMS/Public/Editors',
+        }).type,
+      ).toBe('GET_RELATED_PERMISSIONS')
+    })
+
+    describe('serviceChecks()', () => {
+      let data: any
+      beforeEach(async () => {
+        data = await Actions.getRelatedPermissions({
+          contentIdOrPath: 1,
+          level: PermissionLevel.Allowed,
+          explicitOnly: true,
+          memberPath: '/Root/IMS/Public/Editors',
+        }).payload(repo)
+      })
+      describe('Given repository.getRelatedPermissions() resolves', () => {
+        it('should return a GET_RELATED_PERMISSIONS action', () => {
+          expect(
+            Actions.getRelatedPermissions({
+              contentIdOrPath: 1,
+              level: PermissionLevel.Allowed,
+              explicitOnly: true,
+              memberPath: '/Root/IMS/Public/Editors',
+            }),
+          ).toHaveProperty('type', 'GET_RELATED_PERMISSIONS')
+        })
+        it('should return mockdata', () => {
+          expect(data.See).toBe(0)
         })
       })
     })


### PR DESCRIPTION
- security.setPermissions action's requestbody param in client-core is changed from object to array because the required format is this:
```
{r:[{identity:"/Root/IMS/BuiltIn/Portal/Visitor", OpenMinor:"allow", Save:"deny"},
{identity:"/Root/IMS/BuiltIn/Portal/Creators", Custom16:"A", Custom17:"1"}]}
```
- setPermissionInheritance method is removed, its functionality is moved to setPermissions as a param

- hasPermission, getPermissions and setPermissions redux actions and related tests are added
- action for permission queries are also added