### PR TITLE
Fix images in the imagegallery example

### DIFF
--- a/examples/sn-react-imagegallery/src/configuration.ts
+++ b/examples/sn-react-imagegallery/src/configuration.ts
@@ -1,6 +1,6 @@
 import { UserManagerSettings } from '@sensenet/authentication-oidc-react'
 
-export const repositoryUrl = 'https://dev.demo.sensenet.com/'
+export const repositoryUrl = 'https://dev.demo.sensenet.com'
 
 export const configuration: UserManagerSettings = {
   client_id: 'spa',


### PR DESCRIPTION
All the images are broken in the imagegallery example because of a double slash in their url.

![image](https://user-images.githubusercontent.com/6968860/91548843-54441b00-e926-11ea-9fa0-cd072ac55958.png)

Since the other imagegallery based example worked as it should, I've searched for differences and found that the repository url in the config has an unnecessary closing slash, so I've removed it.