### PR TITLE
[E2E test] Drawer open/close

### DIFF
--- a/apps/sensenet/cypress/integration/drawer/drawer.spec.ts
+++ b/apps/sensenet/cypress/integration/drawer/drawer.spec.ts
@@ -1,18 +1,18 @@
 import { pathWithQueryParams } from '../../../src/services/query-string-builder'
 
 describe('Drawer', () => {
-  it('clicking on the hamburger menu icon should open the drawer', () => {
+  beforeEach(() => {
     cy.login()
     cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
+  })
 
+  it('clicking on the hamburger menu icon should open the drawer', () => {
     cy.get('[data-test="drawer-expandcollapse-button"]').click()
 
     cy.get('[data-test="drawer"]').should('have.css', 'width', '250px')
   })
 
   it('clicking on the X icon should close the extended view of the drawer', () => {
-    cy.login()
-    cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
     cy.get('[data-test="drawer-expandcollapse-button"]').click()
 
     cy.get('[data-test="drawer-expandcollapse-button"]').click()

--- a/apps/sensenet/cypress/integration/drawer/drawer.spec.ts
+++ b/apps/sensenet/cypress/integration/drawer/drawer.spec.ts
@@ -1,0 +1,22 @@
+import { pathWithQueryParams } from '../../../src/services/query-string-builder'
+
+describe('Drawer', () => {
+  it('clicking on the hamburger menu icon should open the drawer', () => {
+    cy.login()
+    cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
+
+    cy.get('[data-test="drawer-expandcollapse-button"]').click()
+
+    cy.get('[data-test="drawer"]').should('have.css', 'width', '250px')
+  })
+
+  it('clicking on the X icon should close the extended view of the drawer', () => {
+    cy.login()
+    cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
+    cy.get('[data-test="drawer-expandcollapse-button"]').click()
+
+    cy.get('[data-test="drawer-expandcollapse-button"]').click()
+
+    cy.get('[data-test="drawer"]').should('have.css', 'width', '90px')
+  })
+})

--- a/apps/sensenet/cypress/integration/drawer/drawer.spec.ts
+++ b/apps/sensenet/cypress/integration/drawer/drawer.spec.ts
@@ -1,3 +1,4 @@
+import { globals } from '../../../src/globalStyles'
 import { pathWithQueryParams } from '../../../src/services/query-string-builder'
 
 describe('Drawer', () => {
@@ -9,7 +10,7 @@ describe('Drawer', () => {
   it('clicking on the hamburger menu icon should open the drawer', () => {
     cy.get('[data-test="drawer-expandcollapse-button"]').click()
 
-    cy.get('[data-test="drawer"]').should('have.css', 'width', '250px')
+    cy.get('[data-test="drawer"]').should('have.css', 'width', `${globals.common.drawerWidthExpanded}px`)
   })
 
   it('clicking on the X icon should close the extended view of the drawer', () => {
@@ -17,6 +18,6 @@ describe('Drawer', () => {
 
     cy.get('[data-test="drawer-expandcollapse-button"]').click()
 
-    cy.get('[data-test="drawer"]').should('have.css', 'width', '90px')
+    cy.get('[data-test="drawer"]').should('have.css', 'width', `${globals.common.drawerWidthCollapsed}px`)
   })
 })

--- a/apps/sensenet/src/components/drawer/PermanentDrawer.tsx
+++ b/apps/sensenet/src/components/drawer/PermanentDrawer.tsx
@@ -101,7 +101,7 @@ export const PermanentDrawer = () => {
   }
 
   return (
-    <Paper className={clsx(classes.paper, { [classes.opened]: opened })}>
+    <Paper className={clsx(classes.paper, { [classes.opened]: opened })} data-test="drawer">
       <div className={classes.backgroundDiv}>
         <List className={classes.list}>
           <li className={classes.listWrapper}>
@@ -111,7 +111,8 @@ export const PermanentDrawer = () => {
                 className={classes.listButton}
                 button={true}
                 onClick={() => setOpened(!opened)}
-                key="expandcollapse">
+                key="expandcollapse"
+                data-test="drawer-expandcollapse-button">
                 <ListItemIcon className={globalClasses.centered}>
                   <Tooltip
                     className={globalClasses.centered}


### PR DESCRIPTION
Closes #746 

Currently I'm hardcoding the expanded/collapsed widths. Should I import the constants from `globalStyles.ts` instead? eg.
```ts
import { globals } from '../../../src/globalStyles'

// ...

describe('Drawer', () => {
  it('clicking on the hamburger menu icon should open the drawer', () => {
    // ...

    cy.get('[data-test="drawer"]').should('have.css', 'width', `${globals.common.drawerWidthExpanded}px`)
  })

  it('clicking on the X icon should close the extended view of the drawer', () => {
    // ...

    cy.get('[data-test="drawer"]').should('have.css', 'width', `${globals.common.drawerWidthCollapsed}px`)
  })
})
```