### PR TITLE
Add E2E test for content types

### DIFF
--- a/apps/sensenet/cypress/integration/content-types/content-types.spec.ts
+++ b/apps/sensenet/cypress/integration/content-types/content-types.spec.ts
@@ -1,0 +1,40 @@
+import { pathWithQueryParams } from '../../../src/services/query-string-builder'
+
+describe('Content types', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
+      .get('div[aria-label="Content Types"]')
+      .click()
+    cy.get('.ReactVirtualized__Grid__innerScrollContainer')
+    cy.get('.ReactVirtualized__Table__Grid').scrollTo('bottom')
+    cy.xpath('//div[text()="Article"]').scrollIntoView({ duration: 500 }).as('articleRow')
+  })
+
+  it('clicking on the content types menu item should show article', () => {
+    cy.get('@articleRow').should('be.visible')
+  })
+
+  it.skip('right clicking on article should open context menu', () => {
+    cy.get('@articleRow').rightclick()
+
+    const actions = ['Edit', 'Delete', 'Set permissions']
+
+    cy.get('.MuiList-root li[role="menuitem"]')
+      .children()
+      .not('.MuiListItemIcon-root')
+      .should('have.length', actions.length)
+      .each((child, i) => {
+        expect(child.text()).to.eq(actions[i])
+      })
+
+    cy.get('.MuiPopover-root').click()
+  })
+
+  it('double clicking on article should open binary editor', () => {
+    cy.get('@articleRow').dblclick()
+    cy.get('div').contains('Article').should('be.visible')
+    cy.get('.monaco-editor').should('be.visible')
+    cy.get('button[aria-label="Cancel"]').click()
+  })
+})

--- a/apps/sensenet/cypress/integration/content-types/content-types.spec.ts
+++ b/apps/sensenet/cypress/integration/content-types/content-types.spec.ts
@@ -4,9 +4,8 @@ describe('Content types', () => {
   beforeEach(() => {
     cy.login()
     cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
-      .get('div[aria-label="Content Types"]')
+      .get('[data-test="Content Types"]')
       .click()
-    cy.get('.ReactVirtualized__Grid__innerScrollContainer')
     cy.get('.ReactVirtualized__Table__Grid').scrollTo('bottom')
     cy.xpath('//div[text()="Article"]').scrollIntoView({ duration: 500 }).as('articleRow')
   })
@@ -15,26 +14,10 @@ describe('Content types', () => {
     cy.get('@articleRow').should('be.visible')
   })
 
-  it.skip('right clicking on article should open context menu', () => {
-    cy.get('@articleRow').rightclick()
-
-    const actions = ['Edit', 'Delete', 'Set permissions']
-
-    cy.get('.MuiList-root li[role="menuitem"]')
-      .children()
-      .not('.MuiListItemIcon-root')
-      .should('have.length', actions.length)
-      .each((child, i) => {
-        expect(child.text()).to.eq(actions[i])
-      })
-
-    cy.get('.MuiPopover-root').click()
-  })
-
   it('double clicking on article should open binary editor', () => {
     cy.get('@articleRow').dblclick()
     cy.get('div').contains('Article').should('be.visible')
     cy.get('.monaco-editor').should('be.visible')
-    cy.get('button[aria-label="Cancel"]').click()
+    cy.get('[data-test="cancel"]').click()
   })
 })

--- a/packages/sn-controls-react/src/viewcontrols/EditView.tsx
+++ b/packages/sn-controls-react/src/viewcontrols/EditView.tsx
@@ -148,6 +148,7 @@ export const EditView: React.FC<EditViewProps> = (props) => {
         <MediaQuery minDeviceWidth={700}>
           <Button
             aria-label={props.localization?.cancel || 'Cancel'}
+            data-test="cancel"
             color="default"
             className={props.classes?.cancel || defaultClasses.cancel}
             onClick={() => props.handleCancel?.()}>


### PR DESCRIPTION
Few notes:

- The second test case is disabled because the feature doesn't appear to be functional
- I couldn't think of a better way to make the virtual table load everything in the list with Cypress
- Not sure where/if I should be adding `data-test` attributes