### PR TITLE
E2E localization tests

### DIFF
--- a/apps/sensenet/cypress/integration/localization/localization.spec.ts
+++ b/apps/sensenet/cypress/integration/localization/localization.spec.ts
@@ -1,0 +1,46 @@
+import { pathWithQueryParams } from '../../../src/services/query-string-builder'
+
+describe('Localization', () => {
+  beforeEach(() => {
+    cy.login()
+    cy.visit(pathWithQueryParams({ path: '/', newParams: { repoUrl: Cypress.env('repoUrl') } }))
+      .get('[data-test="Localization"]')
+      .click()
+  })
+
+  it('should contain a row with ActionResources.xml', () => {
+    cy.get('.MuiTableCell-root div')
+      .contains('ActionResources.xml')
+      .should('have.text', 'ActionResources.xml')
+      .click({ force: true })
+      .parents('[role="row"]')
+      .get('.MuiCheckbox-root')
+      .should('have.class', 'Mui-checked')
+  })
+
+  it('should have the correct items in the right click menu', () => {
+    cy.get('.MuiTableCell-root div').contains('ActionResources.xml').rightclick({ force: true })
+
+    const expectedMenuItems = ['Download', 'Browse']
+
+    cy.get('[role="presentation"] li')
+      .should('have.length', expectedMenuItems.length)
+      .each(($el) => {
+        expect(expectedMenuItems).to.include($el.text())
+      })
+
+    cy.get('[role="presentation"] [aria-hidden="true" ]:first').click({ force: true })
+
+    cy.get('[role="presentation"] li').should('not.exist')
+  })
+
+  it('should open a binary editor with the content of the item on double click', () => {
+    cy.get('.MuiTableCell-root div').contains('ActionResources.xml').dblclick({ force: true })
+
+    cy.get('[data-test="editor-title"]').should('have.text', 'ActionResources.xml')
+
+    cy.get('button[aria-label="Cancel"]').click()
+
+    cy.get('[data-test="editor-title"]').should('not.exist')
+  })
+})

--- a/apps/sensenet/src/components/editor/sn-monaco-editor.tsx
+++ b/apps/sensenet/src/components/editor/sn-monaco-editor.tsx
@@ -79,7 +79,9 @@ export const SnMonacoEditor: React.FunctionComponent<SnMonacoEditorProps> = (pro
         }
       }}>
       <div className={clsx([globalClasses.centeredVertical, classes.header])}>
-        <div className={classes.title}>{props.renderTitle()}</div>
+        <div className={classes.title} data-test="editor-title">
+          {props.renderTitle()}
+        </div>
         <div className={classes.headerButtonWrapper}>
           {props.additionalButtons ? props.additionalButtons : null}
           <Button


### PR DESCRIPTION
This PR adds the E2E tests for #795. I was not able to properly test the `cy.get` with `data-test="editor-title"` because this is not yet available in the test environment. And the right click menu only contains `Download` and `Browse` instead of all the items listed in the issue. Is this a bug or is that the expected result?